### PR TITLE
Small fixes to datepicker and accordion for theme alignment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,7 +35,7 @@
             "styles": [
               {
                 "input": "src/styles/uswds-styles.scss",
-                "inject": true,
+                "inject": false,
                 "bundleName": "uswds-styles"
               },
               {

--- a/projects/uswds-components/src/lib/datepicker/calendar/calendar-body.html
+++ b/projects/uswds-components/src/lib/datepicker/calendar/calendar-body.html
@@ -37,6 +37,7 @@
   <button
   role="gridcell"
   class="usa-date-picker__calendar__date"
+  [hover-class]="'usa-date-picker__calendar__date--focused'"
   [ngClass]="data.item.cssClasses"
   [tabindex]="_isActiveCell(data.rowIndex, data.colIndex) ? 0 : -1"
   [attr.aria-disabled]="!data.item.enabled"

--- a/projects/uswds-components/src/lib/datepicker/calendar/month-view.html
+++ b/projects/uswds-components/src/lib/datepicker/calendar/month-view.html
@@ -8,10 +8,6 @@
         <span [attr.title]="day.long">{{day.narrow}}</span>
       </th>
     </tr>
-    <tr>
-      <!-- Empty divider for header and calendar contents -->
-      <th aria-hidden="true" colspan="7"></th>
-    </tr>
   </thead>
   <tbody usa-calendar-body
          [label]="_monthLabel"

--- a/projects/uswds-components/src/lib/datepicker/calendar/multi-year-view.html
+++ b/projects/uswds-components/src/lib/datepicker/calendar/multi-year-view.html
@@ -8,10 +8,6 @@
         </td>
         <td colspan="3">
           <table class="usa-date-picker__calendar__table" role="grid">
-            <thead aria-hidden="true">
-              <!-- Empty Divider -->
-              <tr><th colspan="4"></th></tr>
-            </thead>
             <tbody usa-calendar-body
                    [view]="'multi-year'"
                    [rows]="_years"

--- a/projects/uswds-components/src/lib/datepicker/calendar/year-view.html
+++ b/projects/uswds-components/src/lib/datepicker/calendar/year-view.html
@@ -1,8 +1,4 @@
 <table class="usa-date-picker__calendar__table" role="grid">
-  <thead aria-hidden="true">
-    <!-- Empty Divider -->
-    <tr><th colspan="4"></th></tr>
-  </thead>
   <tbody usa-calendar-body
          [label]="_yearLabel"
          [rows]="_months"

--- a/projects/uswds-components/src/lib/datepicker/date-picker.module.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-picker.module.ts
@@ -13,6 +13,7 @@ import { DateAdapter } from "./dateadapter/date-adapter";
 import { NativeDateAdapter } from "./dateadapter/native-date-adapter";
 import { USA_DATE_FORMATS } from "./dateadapter/date-formats";
 import { USA_NATIVE_DATE_FORMATS } from "./dateadapter/native-date-formats";
+import { HoverClassModule } from "../util/hover-class";
 
 
 @NgModule({
@@ -32,6 +33,7 @@ import { USA_NATIVE_DATE_FORMATS } from "./dateadapter/native-date-formats";
   ],
   imports: [
     CommonModule,
+    HoverClassModule,
   ],
   providers: [
     {provide: DateAdapter, useClass: NativeDateAdapter},

--- a/projects/uswds-components/src/lib/util/hover-class.ts
+++ b/projects/uswds-components/src/lib/util/hover-class.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { Directive, HostListener, ElementRef, Input, NgModule } from '@angular/core';
+
+/** For internal use - directive that adds or removes class based on hover */
+@Directive({
+  selector: '[hover-class]'
+})
+export class HoverClassDirective {
+
+  constructor(public elementRef: ElementRef) { }
+  @Input('hover-class') hoverClass:any;  
+
+  @HostListener('mouseenter') onMouseEnter() {
+    this.elementRef.nativeElement.classList.add(this.hoverClass);
+ }
+
+  @HostListener('mouseleave') onMouseLeave() {
+    this.elementRef.nativeElement.classList.remove(this.hoverClass);
+  }
+
+}
+
+
+@NgModule({
+  declarations: [HoverClassDirective],
+  imports: [CommonModule],
+  exports: [HoverClassDirective]
+})
+export class HoverClassModule {}

--- a/src/app/accordion/demos/accordion-toggle/accordion-toggle.component.html
+++ b/src/app/accordion/demos/accordion-toggle/accordion-toggle.component.html
@@ -10,7 +10,7 @@
 
   <usa-accordion-item id="dynamicPanel2">
     <ng-template UsaAccordionHeader>
-      <b class="text-primary">I am a <i>Template</i> Header</b>
+      <b class="text-primary-darker">I am a <i>Template</i> Header</b>
     </ng-template>
     <ng-template UsaAccordionContent>
       Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon

--- a/src/app/accordion/demos/basic/accordion-basic.component.html
+++ b/src/app/accordion/demos/basic/accordion-basic.component.html
@@ -21,7 +21,7 @@
 
   <usa-accordion-item>
     <ng-template UsaAccordionHeader>
-      <b class="text-primary">I am a <i>Template</i> Header</b>
+      <b class="text-primary-darker">I am a <i>Template</i> Header</b>
     </ng-template>
     <ng-template UsaAccordionContent>
       Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry 

--- a/src/app/accordion/demos/disable-animation/disable-animation.component.html
+++ b/src/app/accordion/demos/disable-animation/disable-animation.component.html
@@ -14,7 +14,7 @@
 
   <usa-accordion-item>
     <ng-template UsaAccordionHeader>
-      <b class="text-primary">I am a <i>Template</i> Header</b>
+      <b class="text-primary-darker">I am a <i>Template</i> Header</b>
     </ng-template>
     <ng-template UsaAccordionContent>
       Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry 

--- a/src/app/accordion/demos/multi-select/accordion-multi-select.component.html
+++ b/src/app/accordion/demos/multi-select/accordion-multi-select.component.html
@@ -13,7 +13,7 @@
 
   <usa-accordion-item>
     <ng-template UsaAccordionHeader>
-      <b class="text-primary">I am a <i>Template</i> Header</b>
+      <b class="text-primary-darker">I am a <i>Template</i> Header</b>
     </ng-template>
     <ng-template UsaAccordionContent>
       Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry 

--- a/src/app/shared/theme-switcher/theme-switcher.component.ts
+++ b/src/app/shared/theme-switcher/theme-switcher.component.ts
@@ -4,7 +4,7 @@ import { ThemeSwitcherService } from "./theme-switcher.service";
 @Component({
   selector: `usa-theme-switcher`,
   template: `
-    <select #select class="usa-select display-inline width-auto bg-primary-dark text-base-lightest">
+    <select #select class="usa-select display-inline width-auto bg-primary-dark text-base-lightest" aria-label="Application Theme Switcher">
       <option value="uswds">USWDS Styles</option>
       <option value="samStyles">Sam Styles</option>
     </select>
@@ -13,18 +13,23 @@ import { ThemeSwitcherService } from "./theme-switcher.service";
 export class ThemeSwitcherComponent implements AfterViewInit {
   @ViewChild('select') themeSelector: ElementRef<HTMLSelectElement>;
   
+  currentStyle = 'uswds';
+
   constructor(
     private themeSwitcherService: ThemeSwitcherService
   ) {}
 
   ngAfterViewInit() {
     this.themeSelector.nativeElement.addEventListener('change', ($event) => {
-      const value = ($event.target as HTMLSelectElement).value;
-      if (value === 'uswds') {
-        this.themeSwitcherService.removeStyle('theme');
-      } else if (value === 'samStyles') {
+      this.currentStyle = ($event.target as HTMLSelectElement).value;
+      if (this.currentStyle === 'uswds') {
+        this.themeSwitcherService.setStyle('theme', 'uswds-styles.css');
+      } else if (this.currentStyle  === 'samStyles') {
         this.themeSwitcherService.setStyle('theme', 'sam-styles.css');
       }
-    })
+    });
+
+    this.themeSwitcherService.setStyle('theme', 'uswds-styles.css');
+
   }
 }

--- a/src/app/shared/theme-switcher/theme-switcher.module.ts
+++ b/src/app/shared/theme-switcher/theme-switcher.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { ThemeSwitcherService } from "./theme-switcher.service";
-import { ThemeSwitcherComponent } from "./theme-swotcher.component";
+import { ThemeSwitcherComponent } from "./theme-switcher.component";
 
 
 @NgModule({


### PR DESCRIPTION
 - Update accordion demo template header text to be slightly darker for 508 compliance
 - Add a hover class directive - This directive can be used to apply/remove a class on hover in and hover out
 - Remove empty table headers as they cause 508 issues