### PR TITLE
Fixing checkbox and datepicker icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "ghpages": "ng build --prod --base-href \"https://gsa.github.io/ngx-uswds/\" && npx angular-cli-ghpages --dir=dist/usa-components"
+    "ghpages": "ng build --prod --base-href \"https://gsa.github.io/ngx-uswds/\" && touch dist/usa-components/.nojekyll && npx angular-cli-ghpages --dir=dist/usa-components"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Per this blog post: https://www.bennadel.com/blog/3181-including-node-modules-and-vendors-folders-in-your-github-pages-site.htm

GHpages includes Jekyll in its build process which is configured by default to ignore node_modules. SAM-styles gets it's USWDS icons from node_modules, so need to include these. Based on that blog adding a .nojekyll file disables jekyll, which we are not using, resolving this issue. I updated the ghpages script so that this file is added each time ghpages is pushed to.