### PR TITLE
Add basic input demo

### DIFF
--- a/src/app/components/input/demos/basic/input-basic.component.html
+++ b/src/app/components/input/demos/basic/input-basic.component.html
@@ -1,0 +1,39 @@
+<label class="usa-label" for="input-type-text">Text input label</label>
+<input
+  class="usa-input"
+  id="input-type-text"
+  name="input-type-text"
+  type="text"
+/>
+
+<label class="usa-label" for="input-focus">Text input focused</label>
+<input
+  class="usa-input usa-focus"
+  id="input-focus"
+  name="input-focus"
+  type="text"
+/>
+
+<div class="usa-form-group usa-form-group--error">
+  <label class="usa-label usa-label--error" for="input-error"
+    >Text input error</label
+  >
+  <span class="usa-error-message" id="input-error-message"
+    >Helpful error message</span
+  >
+  <input
+    class="usa-input usa-input--error"
+    id="input-error"
+    name="input-error"
+    type="text"
+    aria-describedby="input-error-message"
+  />
+</div>
+
+<label class="usa-label" for="input-success">Text input success</label>
+<input
+  class="usa-input usa-input--success"
+  id="input-success"
+  name="input-success"
+  type="text"
+/>

--- a/src/app/components/input/demos/basic/input-basic.component.ts
+++ b/src/app/components/input/demos/basic/input-basic.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'usa-input-basic',
+  templateUrl: './input-basic.component.html',
+})
+export class InputBasicComponent {}

--- a/src/app/components/input/demos/basic/input-basic.module.ts
+++ b/src/app/components/input/demos/basic/input-basic.module.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { InputBasicComponent } from "./input-basic.component";
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [
+    InputBasicComponent
+  ],
+  exports: [
+    InputBasicComponent
+  ]
+})
+export class InputBasicModule { }

--- a/src/app/components/input/input.module.ts
+++ b/src/app/components/input/input.module.ts
@@ -3,6 +3,8 @@ import { NgModule } from "@angular/core";
 import { DocumentationComponentsSharedModule, DocumentationDemoList } from '../../shared';
 import { DemoWrapperComponent } from '../../shared/demo-wrapper.component';
 import { DocumentationExamplesPage } from '../../shared/examples-page/examples.component';
+import { InputBasicComponent } from './demos/basic/input-basic.component';
+import { InputBasicModule } from './demos/basic/input-basic.module';
 import { InputPrefixAndSuffixComponent } from './demos/prefix-and-suffix/input-prefix-and-suffix.component';
 import { InputPrefixAndSuffixModule } from './demos/prefix-and-suffix/input-prefix-and-suffix.module';
 import { InputPrefixComponent } from './demos/prefix/input-prefix.component';
@@ -12,6 +14,14 @@ import { InputSuffixModule } from './demos/suffix/input-suffix.module';
 declare var require: any;
 
 const DEMOS = {
+  basic: {
+    title: 'Basic Input',
+    type: InputBasicComponent,
+    code: require('!!raw-loader!./demos/basic/input-basic.component'),
+    markup: require('!!raw-loader!./demos/basic/input-basic.component.html'),
+    module: require('!!raw-loader!./demos/basic/input-basic.module'),
+    path: 'src/app/input/demos/basic',
+  },
   prefix: {
     title: 'Input with prefix',
     type: InputPrefixComponent,
@@ -64,7 +74,8 @@ export const ROUTES = [
     DocumentationComponentsSharedModule,
     InputPrefixModule,
     InputSuffixModule,
-    InputPrefixAndSuffixModule
+    InputPrefixAndSuffixModule,
+    InputBasicModule
   ],
 })
 export class InputModule {


### PR DESCRIPTION
Adding demo to input page to show input without prefix or suffix. Used USWDS demo to show different states that can be applied to a basic input.