### PR TITLE
Update export of FileInputModule

### DIFF
--- a/projects/uswds-components/src/lib/file-input/file-input.module.ts
+++ b/projects/uswds-components/src/lib/file-input/file-input.module.ts
@@ -15,7 +15,8 @@ import { UsaFilePreviewDirective } from "./file-preview.directive";
     UsaFilePreviewDirective,
   ],
   exports: [
-    UsaFileInputComponent
+    UsaFileInputComponent,
+    UsaFilePreviewDirective
   ],
   providers: [
     FileInputConfig


### PR DESCRIPTION
Ensure that UsaFilePreviewDirective is being exported so it can be used to display progress indicator for file-upload-table on SDS