### PR TITLE
Fix stackblitz error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "usa-components",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usa-components",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "scripts": {
     "ng": "ng",
     "start": "npm run sandbox-icons && npm run docs:json && start-storybook -p 4200",

--- a/projects/uswds-components/package.json
+++ b/projects/uswds-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsa-sam/ngx-uswds",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/GSA/ngx-uswds.git"

--- a/projects/uswds-components/src/lib/accordion/accordion.component.ts
+++ b/projects/uswds-components/src/lib/accordion/accordion.component.ts
@@ -10,33 +10,6 @@ import { UsaAccordionConfig } from './accordion.config';
 import { AnimationEvent } from '@angular/animations';
 import { UsaExpansionAnimations } from './accordion-animations';
 
-@Directive({
-  selector: 'button[UsaAccordionToggle]',
-  host: {
-    'type': 'button',
-    '[disabled]': 'panel.disabled',
-    'class': 'usa-accordion__button',
-    '[class.collapsed]': '!panel.expanded',
-    '[attr.aria-expanded]': 'panel.expanded',
-    '[attr.aria-controls]': 'panel.expanded ? panel.id : undefined',
-    '[attr.aria-disabled]': 'panel.disabled && panel.expanded ? true : undefined',
-    '[attr.aria-label]': 'panel.ariaLabel',
-    '(click)': 'accordion.toggle(panel.id)',
-  }
-})
-export class UsaAccordionToggle {
-  static ngAcceptInputType_UsaAccordionToggle: UsaAccordionItem | '';
-
-  @Input()
-  set UsaAccordionToggle(panel: UsaAccordionItem) {
-    if (panel) {
-      this.panel = panel;
-    }
-  }
-
-  constructor(public accordion: UsaAccordionComponent, @Optional() @Host() public panel: UsaAccordionItem) { }
-}
-
 @Component({
   selector: 'usa-accordion',
   exportAs: 'usaAccordion',
@@ -290,4 +263,31 @@ export class UsaAccordionComponent implements AfterContentChecked  {
   private _getPanelElementHeaderButton(panelId: string): HTMLElement | null {
     return this._element.nativeElement.querySelector('#' + panelId + '-header button');
   }
+}
+
+@Directive({
+  selector: 'button[UsaAccordionToggle]',
+  host: {
+    'type': 'button',
+    '[disabled]': 'panel.disabled',
+    'class': 'usa-accordion__button',
+    '[class.collapsed]': '!panel.expanded',
+    '[attr.aria-expanded]': 'panel.expanded',
+    '[attr.aria-controls]': 'panel.expanded ? panel.id : undefined',
+    '[attr.aria-disabled]': 'panel.disabled && panel.expanded ? true : undefined',
+    '[attr.aria-label]': 'panel.ariaLabel',
+    '(click)': 'accordion.toggle(panel.id)',
+  }
+})
+export class UsaAccordionToggle {
+  static ngAcceptInputType_UsaAccordionToggle: UsaAccordionItem | '';
+
+  @Input()
+  set UsaAccordionToggle(panel: UsaAccordionItem) {
+    if (panel) {
+      this.panel = panel;
+    }
+  }
+
+  constructor(public accordion: UsaAccordionComponent, @Optional() @Host() public panel: UsaAccordionItem) { }
 }

--- a/projects/uswds-formly/package.json
+++ b/projects/uswds-formly/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@gsa-sam/uswds-formly",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "peerDependencies": {
     "@angular/common": "~13.3.11",
     "@angular/core": "~13.3.11",
     "@angular/forms": "~13.3.11",
     "uswds": "^2.11.2",
     "@ngx-formly/core": "^5.10.23",
-    "@gsa-sam/uswds-components": "13.0.0-beta.1"
+    "@gsa-sam/uswds-components": "13.0.0-beta.2"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
Error is occurring when trying to create SDS demo in stackblitz.

<img width="522" alt="Screen Shot 2022-12-21 at 10 23 28 AM" src="https://user-images.githubusercontent.com/72805180/208940910-1039831a-c0d2-4b2d-a6f5-237deabef277.png">

This is tied to UsaAccordionToggle being declared in .ts first. That directive has a reference to UsaAccordionComponent in its constructor. When this is compiled to .mjs it leads to UsaAccordionComponent being referenced before its class is declared. Swapping the order in which these classes are declared in the .ts file causes the order to also be swapped in the resulting .mjs file, which should resolve the error seen on stackblitz.