### PR TITLE
Add component coverage artifact to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,13 @@ jobs:
               run: |
                 npm run build:components \
                 && npm run build:formly
-            - name: Run tests
-              # formly code does not have tests at all change back to npm run test when it does
+            - name: Run component tests with coverage
+              # formly code does not have tests at all; scope coverage to components
               run: npm run test:components
+            - name: Upload component coverage artifact
+              if: always()
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: uswds-components-coverage
+                  path: coverage/uswds-components/**
+                  if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,11 @@ jobs:
                 npm run build:components \
                 && npm run build:formly
             - name: Run component tests with coverage
+              id: component-tests
               # formly code does not have tests at all; scope coverage to components
               run: npm run test:components
             - name: Upload component coverage artifact
-              if: always()
+              if: ${{ steps.component-tests.outcome == 'success' }}
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: uswds-components-coverage

--- a/projects/uswds-components/src/lib/header/header.component.spec.ts
+++ b/projects/uswds-components/src/lib/header/header.component.spec.ts
@@ -5,7 +5,7 @@ import { UsaNavigationLink } from '../util/navigation';
 import { UsaHeaderPrimaryLink } from './header.model';
 import { UsaHeaderModule } from './header.module';
 
-fdescribe('HeaderComponent', () => {
+describe('HeaderComponent', () => {
   let component: MockHeaderComponent;
   let fixture: ComponentFixture<MockHeaderComponent>;
 

--- a/projects/uswds-components/src/lib/modal/modal.spec.ts
+++ b/projects/uswds-components/src/lib/modal/modal.spec.ts
@@ -119,7 +119,7 @@ class UsaModalTestComponent {
     this.modalRef = this.modalService.open(content, this.modalOptions)
     this.modalRef.result.then((result) => {
       this.closeResult = result;
-    });
+    }, () => {});
   }
 
   close(reason) {

--- a/projects/uswds-components/src/lib/modal/modal.spec.ts
+++ b/projects/uswds-components/src/lib/modal/modal.spec.ts
@@ -106,7 +106,8 @@ describe('UsaModal', () => {
   `
 })
 class UsaModalTestComponent {
-  closeResult: ModalDismissReasons;
+  closeResult: string;
+  dismissReason: ModalDismissReasons;
   modalOptions: UsaModalOptions = {ariaLabelledBy: 'modal-test'};
   modalRef: UsaModalRef;
 
@@ -119,7 +120,9 @@ class UsaModalTestComponent {
     this.modalRef = this.modalService.open(content, this.modalOptions)
     this.modalRef.result.then((result) => {
       this.closeResult = result;
-    }, () => {});
+    }, (reason: ModalDismissReasons) => {
+      this.dismissReason = reason;
+    });
   }
 
   close(reason) {


### PR DESCRIPTION
## Description

Add the component library test coverage artifact to CI and make the existing component test step meaningful for pull requests and `main`.

Changes include:

- Update `.github/workflows/ci.yaml` so the test step is explicitly named `Run component tests with coverage` and remains scoped to `npm run test:components`.
- Add a pinned `actions/upload-artifact` step that uploads `coverage/uswds-components/**` as `uswds-components-coverage` and fails if the coverage output is missing.
- Fix an accidental focused Jasmine suite in `HeaderComponent` by changing `fdescribe` back to `describe`, restoring the full component test suite.
- Handle expected modal dismissal rejections in the modal test component so the full suite can run cleanly.

## Motivation and Context

The component library test script already runs headless with `--code-coverage`, but CI did not preserve the generated coverage report as an artifact. This change makes the coverage output available from CI runs and restores the full component test suite so the CI check reflects all currently configured component specs.

Note: making the CI job a required check is enforced through GitHub branch protection/rulesets. This PR keeps the workflow running on pull requests and pushes to `main`, using the existing `Build and Run Tests` job/check for that required-check configuration.

Closes #187

## Type of Change (Select One and Apply Label)

- [ ] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [ ] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [x] Documentation / configuration update → Apply `documentation` label

## How to Test

1. Use Node 24 from `.nvmrc`:
   ```bash
   fnm use 24
   node --version
   ```
2. Install dependencies from the committed lockfile:
   ```bash
   npm ci
   ```
3. Run the component test target used by CI:
   ```bash
   npm run test:components
   ```
4. Confirm all component specs run and pass:
   ```text
   TOTAL: 58 SUCCESS
   ```
5. Confirm coverage is reported in the terminal output and written to disk:
   ```bash
   test -f coverage/uswds-components/lcov.info
   test -f coverage/uswds-components/index.html
   ```
6. Build both publishable libraries as CI does before tests:
   ```bash
   npm run build:components
   npm run build:formly
   ```
7. In GitHub Actions, confirm the `Build and Run Tests` job includes an uploaded artifact named `uswds-components-coverage` containing the component coverage report.

**Expected result:** `npm run test:components`, `npm run build:components`, and `npm run build:formly` pass. The component test run executes all 58 specs, prints a coverage summary, and generates `coverage/uswds-components/` for upload by CI.

Observed local coverage after restoring the full suite:

```text
Statements   : 51.34% ( 764/1488 )
Branches     : 27.51% ( 134/487 )
Functions    : 38.48% ( 157/408 )
Lines        : 51.47% ( 731/1420 )
```

## Screenshots (if appropriate)

N/A — CI workflow and test configuration changes only.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [ ] `format:check` passes (`npm run format:check`) — script is not configured in this repo
- [ ] `lint` passes (`npm run lint`) — no Angular lint target is configured in this repo
- [ ] `build-prod` passes (`npm run build-prod`) — script is not configured in this repo
- [x] Tests pass and coverage is reported (`npm run test`) — verified scoped CI target with `npm run test:components`
- [x] If this change requires a documentation update, I have updated it accordingly — N/A, no user-facing docs required
- [x] If there are dependent changes, they have been merged and published in downstream modules — N/A
