### PR TITLE
Fix gh-pages deploy permissions (403 on push to main)

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -7,8 +7,7 @@ jobs:
   Build-And-Deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
+      contents: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Description

The **Deploy to Github Pages** workflow fails on push to `main` when force-pushing the built Storybook to the `gh-pages` branch:

```
remote: Permission to GSA/ngx-uswds.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/GSA/ngx-uswds.git/': The requested URL returned error: 403
```

`JamesIves/github-pages-deploy-action` commits and force-pushes to the `gh-pages` branch using `GITHUB_TOKEN`, which requires `contents: write`. The job previously granted `contents: read` + `pages: write`. `pages: write` only applies to GitHub's native Pages deployment (`actions/deploy-pages`), which this workflow does not use.

This change replaces the permissions with `contents: write` so the token can push to `gh-pages`.

```yaml
permissions:
  contents: write
```

## Motivation and Context

Storybook docs deployment to GitHub Pages is currently broken on every merge to `main`. See failing run: https://github.com/GSA/ngx-uswds/actions/runs/31439467430/job/93620898803

Closes #<!-- issue number if one exists -->

## Type of Change (Select One and Apply Label)

- [x] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [ ] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [ ] Documentation / configuration update → Apply `documentation` label

## How to Test

Because this workflow only runs on `push` to `main`, it cannot be fully validated from a PR. To verify:

1. Confirm the diff grants `contents: write` on the `Build-And-Deploy` job.
2. Confirm repo **Settings → Actions → General → Workflow permissions** is not overriding to read-only, or that the workflow-level permission is sufficient (it takes precedence).
3. Confirm there is no branch protection rule on `gh-pages` blocking `github-actions[bot]`.
4. After merge to `main`, watch the **Deploy to Github Pages** run complete the `Deploy 🚀` step successfully and confirm the site updates.

**Expected result:** The `Deploy 🚀` step force-pushes to `gh-pages` without a 403 and the run succeeds.

## Screenshots (if appropriate)

N/A

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [ ] `format:check` passes (`npm run format:check`) — N/A (workflow YAML only)
- [ ] `lint` passes (`npm run lint`) — N/A
- [ ] `build-prod` passes (`npm run build-prod`) — N/A
- [ ] Tests pass and coverage is reported (`npm run test`) — N/A
- [ ] If this change requires a documentation update, I have updated it accordingly
- [ ] If there are dependent changes, they have been merged and published in downstream modules
