### PR TITLE
Add Dependabot auto-merge workflow for minor/patch updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,12 +9,18 @@ updates:
       default-days: 5
       semver-major-days: 60
     groups:
-      npm-dependencies:
+      minor:
         patterns:
           - '*'
         update-types:
           - 'minor'
+      patch:
+        patterns:
+          - '*'
+        update-types:
           - 'patch'
+    # Major updates are intentionally ungrouped so each opens as its own PR
+    # and requires human review — they are never auto-merged.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge minor and patch updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Split the single `npm-dependencies` Dependabot group (which lumped minor and patch updates together) into separate `minor` and `patch` groups, and add an auto-merge workflow that merges minor/patch Dependabot PRs automatically once required checks pass. Major updates are intentionally left ungrouped so each opens as its own standalone PR requiring human review.

Modeled on the team-approved example in `GSA/ngx-uswds-icons`.

**Files changed:**

- `.github/dependabot.yaml` — replace `npm-dependencies` group with `minor` and `patch` groups; majors ungrouped
- `.github/workflows/dependabot-auto-merge.yml` — new workflow: SHA-pinned `dependabot/fetch-metadata`, auto-merges `semver-minor` and `semver-patch` only, least-privilege permissions

## Motivation and Context

Closes #228

Auto-merge is a per-PR decision, so the PR boundary must equal the risk boundary. A single group that lumps minor+patch into one PR type makes it impossible to distinguish them at merge time. Splitting the groups enforces that boundary in Dependabot itself.

## Type of Change (Select One and Apply Label)

- [ ] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [ ] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [x] Documentation / configuration update → Apply `documentation` label

## How to Test

1. Review `.github/dependabot.yaml` — confirm `minor` and `patch` are separate groups; confirm no `major` group exists
2. Review `.github/workflows/dependabot-auto-merge.yml` — confirm `if:` guard checks `github.actor == 'dependabot[bot]'` and auto-merge step only fires for `semver-minor` or `semver-patch`
3. Confirm CI (`ci build` workflow) passes on this PR
4. ⚠️ **Admin action required:** Enable "Allow auto-merge" on the repo under Settings → General — currently `false`; `gh pr merge --auto` will fail silently until this is on
5. ⚠️ **DevSecOps action required:** Enable required status checks on branch protection for `main` so `--auto` only completes after tests pass

**Expected result:** Minor and patch Dependabot PRs auto-merge once CI is green; major Dependabot PRs open standalone and wait for human approval.

## Screenshots (if appropriate)

N/A — configuration-only change.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [ ] `lint` passes (`npm run lint`) — no lintable source files changed
- [ ] `build-prod` passes (`npm run build-prod`) — no source files changed
- [ ] Tests pass and coverage is reported (`npm run test`) — no source files changed
- [ ] If this change requires a documentation update, I have updated it accordingly
- [ ] If there are dependent changes, they have been merged and published in downstream modules
