### PR TITLE
Add Dependabot auto-approve workflow for minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-approve
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # github-actions[bot] approving a dependabot[bot] PR is a DIFFERENT actor
+      # than the PR author, so the approval satisfies required_approving_review_count.
+      # Scoped to minor/patch to mirror the auto-merge policy; majors stay human-gated.
+      - name: Approve minor and patch updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,6 +1,6 @@
 name: Dependabot auto-approve
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   pull-requests: write
@@ -8,7 +8,12 @@ permissions:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # pull_request_target gives the workflow a writable token for Dependabot PRs.
+    # Keep this job free of checkout/build/test steps so untrusted PR code never runs
+    # in the trusted target-repository context.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'GSA/ngx-uswds'
 
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
## Description

Adds `.github/workflows/dependabot-auto-approve.yml`, automating the approval-count step for the Dependabot auto-merge pipeline started in #229.

#229 shipped the split groups and the auto-merge workflow (`gh pr merge --auto`), but minor/patch PRs still need an approval before that flow can proceed. This PR adds the documented auto-approve step, per [GitHub's documented pattern](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request).

**How it works:** `github-actions[bot]` approving a `dependabot[bot]` PR is a *different* actor than the PR author, so the approval counts toward `required_approving_review_count` (GitHub's self-approval prohibition only blocks approving your *own* PR). Scoped to `semver-minor` / `semver-patch` to mirror the auto-merge policy; majors stay human-gated.

**Files changed:**
- `.github/workflows/dependabot-auto-approve.yml` — new workflow: SHA-pinned `dependabot/fetch-metadata`, runs on `pull_request_target` for a writable Dependabot approval token, guarded by `github.event.pull_request.user.login == 'dependabot[bot]'` and `github.repository == 'GSA/ngx-uswds'`, least-privilege `permissions: { pull-requests: write }`, approves minor/patch only, and deliberately does **not** check out or execute PR code

## Motivation and Context

Refs #228 (follow-up to #229, which is merged)

Automates the review-count approval needed by the auto-merge flow for minor/patch Dependabot PRs, while majors remain standalone for human review. Verified in #229 that once a minor PR is approved, `--auto` merges it after CI passes (e.g. #160 merged by `github-actions`, not a human). Full zero-touch still depends on the DevOps ruleset/merge-actor decision documented below.

### ⚠️ Required DevOps / DevSecOps decision before claiming full zero-touch

This workflow fixes the approval-token issue and can satisfy `required_approving_review_count`, but **it does not by itself bypass `require_code_owner_review`**. We are intentionally keeping code-owner review mandatory for human PRs.

Important ruleset caveat found during review: GitHub ruleset bypasses are honored by the synchronous REST merge endpoint for the **caller** that has bypass authority, but async auto-merge (`gh pr merge --auto` / GitHub auto-merge completion) does not later re-check a bypass granted to the PR author. In other words, adding `dependabot[bot]` to the bypass list is necessary for policy scoping, but may not be sufficient with the existing `--auto` merge path.

To get true zero-touch while preserving code-owner review for humans, DevOps needs to choose one of these approaches:

- **Preferred policy shape:** keep `require_code_owner_review: true` for humans and configure an approved automation actor (GitHub App or machine user) that is allowed to bypass the review ruleset for PRs only, then use that actor for a post-CI direct merge path.
- **Fallback / current safe behavior:** keep the existing human code-owner approval requirement for Dependabot PRs. Once a code-owner approves, #229's `--auto` workflow completes the merge after CI passes.

Additional repo setting to confirm for this PR's auto-approval step:

- ✅ Confirm the repository/org Actions setting **allows GitHub Actions to create and approve pull requests**; otherwise GitHub may reject the `gh pr review --approve` call even from `pull_request_target`.

Note: this very PR touches `/.github/`, which CODEOWNERS routes to `@GSA/sam-shared-frontend-admin @christyhermansen`, so it will require a DevSecOps code-owner approval to land.

### Context: why Dependabot (not Renovate)

The ADR-0008 exemplar (HHS/OPRE-OPS) achieves this policy with **Renovate**, which auto-merges as a first-class App actor. A code search shows **Renovate has zero adoption across the GSA org**, while **Dependabot is the standard (49 repos)**. Rather than pioneer a new third-party app (fresh DevSecOps/ATO review), this PR implements the same *policy* using GSA's established *tooling*.

## How to Test

1. Review `.github/workflows/dependabot-auto-approve.yml` — confirm it uses `pull_request_target`, does not check out or execute PR code, guards on `github.event.pull_request.user.login == 'dependabot[bot]'` plus `github.repository == 'GSA/ngx-uswds'`, and the approve step only fires for `semver-minor` / `semver-patch`
2. Confirm CI (`ci build`) passes on this PR
3. After merge **and** the DevOps ruleset/merge-actor decision above is in place, wait for the next minor/patch Dependabot PR and confirm it:
   - is auto-approved by `github-actions`
   - either auto-merges after CI through the approved bypass-capable merge path, or (fallback) merges after a code-owner approval arms the existing `--auto` flow
4. Confirm a major Dependabot PR (e.g. a future `@babel/core` major) opens standalone and is **not** auto-approved/merged

**Expected result:** the approval-count part of the Dependabot pipeline is automated; full zero-touch additionally depends on the DevOps ruleset/merge-actor decision above. Human PRs still require code-owner review; majors await a human.

## Screenshots (if appropriate)

N/A — configuration-only change.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [ ] `lint` passes (`npm run lint`) — no lintable source files changed
- [ ] `build-prod` passes (`npm run build-prod`) — no source files changed
- [ ] Tests pass and coverage is reported (`npm run test`) — no source files changed
- [ ] If this change requires a documentation update, I have updated it accordingly
- [ ] If there are dependent changes, they have been merged and published in downstream modules


