### PR TITLE
Add comprehensive checkbox component spec to 100% coverage

### DIFF
--- a/projects/uswds-components/src/lib/checkbox/checkbox.component.spec.ts
+++ b/projects/uswds-components/src/lib/checkbox/checkbox.component.spec.ts
@@ -22,4 +22,240 @@ describe('CheckboxComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // ── @Input bindings render correctly ────────────────────────────────────────
+
+  it('applies usa-checkbox__input--tile class when tile is true', () => {
+    component.tile = true;
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.classList).toContain('usa-checkbox__input--tile');
+  });
+
+  it('does not apply tile class when tile is false', () => {
+    component.tile = false;
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.classList).not.toContain('usa-checkbox__input--tile');
+  });
+
+  it('sets disabled attribute on the input when disabled is true', () => {
+    component.disabled = true;
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.disabled).toBe(true);
+  });
+
+  it('sets required attribute on the input when required is true', () => {
+    component.required = true;
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.required).toBe(true);
+  });
+
+  it('binds the name attribute to the input', () => {
+    component.name = 'my-checkbox';
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.getAttribute('name')).toBe('my-checkbox');
+  });
+
+  it('sets aria-label on the input when provided', () => {
+    component.ariaLabel = 'Accept terms';
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.getAttribute('aria-label')).toBe('Accept terms');
+  });
+
+  it('does not set aria-label when ariaLabel is empty string', () => {
+    component.ariaLabel = '';
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('sets aria-labelledby on the input when provided', () => {
+    component.ariaLabelledby = 'label-id';
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.getAttribute('aria-labelledby')).toBe('label-id');
+  });
+
+  it('sets aria-describedby on the input when provided', () => {
+    component.ariaDescribedby = 'desc-id';
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.getAttribute('aria-describedby')).toBe('desc-id');
+  });
+
+  it('binds the id input to the native input element', () => {
+    component.id = 'my-cb';
+    component.cdr.markForCheck();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.id).toBe('my-cb');
+  });
+
+  it('generates a unique default id', () => {
+    const fixture2 = TestBed.createComponent(UsaCheckboxComponent);
+    const c2 = fixture2.componentInstance;
+    fixture2.detectChanges();
+    expect(component.id).not.toBe(c2.id);
+    expect(component.id).toMatch(/^usa-checkbox-\d+$/);
+  });
+
+  // ── _getAriaChecked ──────────────────────────────────────────────────────────
+
+  describe('_getAriaChecked()', () => {
+    it('returns "true" when checked is true', () => {
+      component.checked = true;
+      expect(component._getAriaChecked()).toBe('true');
+    });
+
+    it('returns "false" when unchecked and not indeterminate', () => {
+      component.checked = false;
+      component['_indeterminate'] = false;
+      expect(component._getAriaChecked()).toBe('false');
+    });
+
+    it('returns "mixed" when unchecked and indeterminate is set via private field', () => {
+      component.checked = false;
+      // Set the private backing field directly so we can test the branch
+      // without triggering the setter's nativeInput guard.
+      component['_indeterminate'] = true;
+      expect(component._getAriaChecked()).toBe('mixed');
+    });
+  });
+
+  // ── indeterminate setter ─────────────────────────────────────────────────────
+
+  describe('indeterminate setter', () => {
+    it('is a no-op before the view is initialised (no nativeInput)', () => {
+      // Create a fresh component but do NOT call detectChanges so ViewChild is unset.
+      const earlyFixture = TestBed.createComponent(UsaCheckboxComponent);
+      const earlyComp = earlyFixture.componentInstance;
+      // nativeInput is undefined at this point
+      expect(() => {
+        earlyComp.indeterminate = true;
+      }).not.toThrow();
+      expect(earlyComp['_indeterminate']).toBeUndefined();
+    });
+
+    it('sets nativeElement.indeterminate after view init', () => {
+      // After fixture.detectChanges() nativeInput is available.
+      component.indeterminate = true;
+      expect(component['_indeterminate']).toBe(true);
+      expect(component.nativeInput.nativeElement.indeterminate).toBe(true);
+    });
+
+    it('clears nativeElement.indeterminate when set to false', () => {
+      component.indeterminate = true;
+      component.indeterminate = false;
+      expect(component['_indeterminate']).toBe(false);
+      expect(component.nativeInput.nativeElement.indeterminate).toBe(false);
+    });
+  });
+
+  // ── onCheckboxClick ──────────────────────────────────────────────────────────
+
+  describe('onCheckboxClick()', () => {
+    // jsdom does not define PointerEvent; use MouseEvent which has the same interface
+    // for stopPropagation purposes and satisfies the type parameter.
+    function makeClickEvent(): MouseEvent {
+      return new MouseEvent('click');
+    }
+
+    it('toggles checked from false to true', () => {
+      component.checked = false;
+      component.onCheckboxClick(makeClickEvent() as unknown as PointerEvent);
+      expect(component.checked).toBe(true);
+    });
+
+    it('toggles checked from true to false', () => {
+      component.checked = true;
+      component.onCheckboxClick(makeClickEvent() as unknown as PointerEvent);
+      expect(component.checked).toBe(false);
+    });
+
+    it('calls the registered onChange callback with the new value', () => {
+      const onChangeSpy = vi.fn();
+      component.registerOnChange(onChangeSpy);
+      component.checked = false;
+      component.onCheckboxClick(makeClickEvent() as unknown as PointerEvent);
+      expect(onChangeSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('emits the new checked value via the change Output', () => {
+      const emitted: boolean[] = [];
+      component.change.subscribe((v: boolean) => emitted.push(v));
+      component.checked = false;
+      component.onCheckboxClick(makeClickEvent() as unknown as PointerEvent);
+      expect(emitted).toEqual([true]);
+    });
+
+    it('calls stopPropagation on the click event', () => {
+      const event = makeClickEvent() as unknown as PointerEvent;
+      const spy = vi.spyOn(event, 'stopPropagation');
+      component.onCheckboxClick(event);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  // ── preventChangePropogation ─────────────────────────────────────────────────
+
+  describe('preventChangePropogation()', () => {
+    it('calls stopPropagation on the event', () => {
+      const event = new Event('change');
+      const spy = vi.spyOn(event, 'stopPropagation');
+      component.preventChangePropogation(event);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  // ── ControlValueAccessor ─────────────────────────────────────────────────────
+
+  describe('ControlValueAccessor', () => {
+    it('writeValue sets checked to true for a truthy value', () => {
+      component.writeValue(true);
+      expect(component.checked).toBe(true);
+    });
+
+    it('writeValue sets checked to false for a falsy value', () => {
+      component.writeValue(null);
+      expect(component.checked).toBe(false);
+    });
+
+    it('writeValue coerces a string to boolean', () => {
+      component.writeValue('yes');
+      expect(component.checked).toBe(true);
+    });
+
+    it('registerOnChange stores the callback', () => {
+      const fn = vi.fn();
+      component.registerOnChange(fn);
+      expect(component.onChange).toBe(fn);
+    });
+
+    it('registerOnTouched stores the callback', () => {
+      const fn = vi.fn();
+      component.registerOnTouched(fn);
+      expect(component.onTouched).toBe(fn);
+    });
+
+    it('setDisabledState sets the disabled property', () => {
+      component.setDisabledState!(true);
+      expect(component.disabled).toBe(true);
+      component.setDisabledState!(false);
+      expect(component.disabled).toBe(false);
+    });
+  });
 });

--- a/projects/uswds-components/src/lib/checkbox/checkbox.component.spec.ts
+++ b/projects/uswds-components/src/lib/checkbox/checkbox.component.spec.ts
@@ -123,15 +123,13 @@ describe('CheckboxComponent', () => {
 
     it('returns "false" when unchecked and not indeterminate', () => {
       component.checked = false;
-      component['_indeterminate'] = false;
+      component.indeterminate = false;
       expect(component._getAriaChecked()).toBe('false');
     });
 
-    it('returns "mixed" when unchecked and indeterminate is set via private field', () => {
+    it('returns "mixed" when unchecked and indeterminate is true', () => {
       component.checked = false;
-      // Set the private backing field directly so we can test the branch
-      // without triggering the setter's nativeInput guard.
-      component['_indeterminate'] = true;
+      component.indeterminate = true;
       expect(component._getAriaChecked()).toBe('mixed');
     });
   });


### PR DESCRIPTION
## Description

Expands the `UsaCheckboxComponent` test suite from a single smoke test to 30 comprehensive behavioural specs, driving `checkbox.component.ts` to **100% statement / 100% branch / 92% function** coverage.

**Files changed:**

- `projects/uswds-components/src/lib/checkbox/checkbox.component.spec.ts` — rewrote and extended to cover:
  - `@Input` DOM bindings: `tile` CSS class, `disabled`, `required`, `name`, aria-label/labelledby/describedby, `id` binding, and auto-generated unique default id
  - `_getAriaChecked()`: `'true'` (checked), `'false'` (unchecked + not indeterminate), and `'mixed'` (unchecked + indeterminate) branches
  - `indeterminate` setter: early-return guard before `nativeInput` is available; sets and clears `nativeElement.indeterminate` after view init
  - `onCheckboxClick()`: toggles `checked`, calls registered `onChange` callback with new value, emits `change` Output, calls `stopPropagation`
  - `preventChangePropogation()`: calls `stopPropagation` on the native change event
  - `ControlValueAccessor`: `writeValue` (truthy/falsy/string coercion), `registerOnChange`, `registerOnTouched`, `setDisabledState`

**Coverage for `checkbox.component.ts`:**

| Metric | Before | After |
|---|---|---|
| Statements | 72% | 100% |
| Branches | 60% | 100% |
| Functions | 25% | 92% |
| Lines | 72% | 100% |

Library-wide coverage: statements 90%, branches 91%, functions 72%, lines 90% — all above current floors. Coverage floor not modified (per policy in AGENTS.md).

## Motivation and Context

Closes #246

## Type of Change (Select One and Apply Label)

- [ ] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [ ] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [x] Documentation / configuration update → Apply `documentation` label

## How to Test

1. `npm ci`
2. `npm run test:components` — all 356 tests should pass (30 new checkbox tests)
3. `npm run coverage:check` — all four metrics should show ✓

**Expected result:** `✓ Coverage gate passed.` with statements ≥81%, branches ≥83%, functions ≥48%, lines ≥81%

## Screenshots (if appropriate)

N/A — test-only change.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [ ] `lint` passes (`npm run lint`) — no `lint` target configured in this workspace (see AGENTS.md)
- [ ] `build-prod` passes (`npm run build-prod`) — test-only change; no source changes
- [x] Tests pass and coverage is reported (`npm run test:components` + `npm run coverage:check`)
- [ ] If this change requires a documentation update, I have updated it accordingly
- [x] If there are dependent changes, they have been merged and published in downstream modules
