### PR TITLE
Add header component test coverage to ~100%

### DIFF
--- a/projects/uswds-components/src/lib/header/header.component.spec.ts
+++ b/projects/uswds-components/src/lib/header/header.component.spec.ts
@@ -1,9 +1,191 @@
-import { Component, ElementRef } from '@angular/core';
+import { Component, ElementRef, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { UsaNavigationLink } from '../util/navigation';
 import { UsaHeaderPrimaryLink } from './header.model';
 import { UsaHeaderModule } from './header.module';
+import { UsaHeaderComponent } from './header.component';
+import { UsaHeaderPrimaryLinkTemplate, UsaHeaderSecondaryLinkTemplate } from './header-selectors';
+import { UsaHeaderSubmenuButton } from './header-submenu.component';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePrimaryNav(): UsaHeaderPrimaryLink[] {
+  return [
+    { text: 'Item 1', id: 'item1', href: '/item1' },
+    { text: 'Item 2', id: 'item2' },
+    {
+      text: 'Item 3',
+      id: 'item3',
+      children: [
+        { text: 'item3Child1', id: 'item3Child1' },
+        { text: 'item3Child2', id: 'item3Child2' },
+      ],
+    },
+    {
+      text: 'Item 4',
+      id: 'item4',
+      isMegamenu: true,
+      children: [
+        { text: 'item4Child1', id: 'item4Child1' },
+        { text: 'item4Child2', id: 'item4Child2' },
+      ],
+    },
+  ];
+}
+
+function makeSecondaryNav(): UsaNavigationLink[] {
+  return [
+    { text: 'Secondary Item 1', id: 'secondaryItem1' },
+    { text: 'Secondary Item 2', id: 'secondaryItem2' },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Mock host components
+// ---------------------------------------------------------------------------
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-header [extended]="extended" [primaryNavItems]="primaryNav" [secondaryNavItems]="secondaryNav"></usa-header>
+  `,
+})
+class MockHeaderComponent {
+  public extended = false;
+
+  constructor(public elementRef: ElementRef) {}
+
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+  secondaryNav: UsaNavigationLink[] = makeSecondaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-header [title]="titleTpl" [primaryNavItems]="primaryNav">
+      <ng-template #titleTpl>
+        <span id="custom-title">Custom Title</span>
+      </ng-template>
+    </usa-header>
+  `,
+})
+class MockHeaderWithTemplateTitleComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: ` <usa-header title="String Title" [primaryNavItems]="primaryNav"></usa-header> `,
+})
+class MockHeaderWithStringTitleComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-header [primaryNavItems]="primaryNav" [menuButtonTemplate]="menuTpl">
+      <ng-template #menuTpl>
+        <span id="custom-menu-btn">Custom Menu</span>
+      </ng-template>
+    </usa-header>
+  `,
+})
+class MockHeaderWithMenuButtonTemplateComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: ` <usa-header [primaryNavItems]="primaryNav" navAriaLabel="My Custom Nav Label"></usa-header> `,
+})
+class MockHeaderWithNavAriaLabelComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: ` <usa-header [primaryNavItems]="primaryNav" [displayOverlayOnMenuOpen]="true"></usa-header> `,
+})
+class MockHeaderWithOverlayComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-header
+      [extended]="extended"
+      [primaryNavItems]="primaryNav"
+      [secondaryNavItems]="secondaryNav"
+      (linkEvent)="lastEvent = $event"
+    ></usa-header>
+  `,
+})
+class MockHeaderWithLinkEventComponent {
+  extended = false;
+  lastEvent: UsaNavigationLink | null = null;
+  primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+  secondaryNav: UsaNavigationLink[] = makeSecondaryNav();
+}
+
+@Component({
+  standalone: false,
+  template: ` <usa-header [primaryNavItems]="primaryNav"></usa-header> `,
+})
+class MockHeaderWithSelectedNavComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = [
+    { text: 'Item 1', id: 'item1', selected: true },
+    { text: 'Item 2', id: 'item2', selected: true },
+    { text: 'Item 3', id: 'item3' },
+  ];
+}
+
+@Component({
+  standalone: false,
+  template: ` <usa-header [primaryNavItems]="primaryNav"></usa-header> `,
+})
+class MockHeaderNoItemsComponent {
+  primaryNav: UsaHeaderPrimaryLink[] = [];
+}
+
+// ---------------------------------------------------------------------------
+// UsaHeaderSubmenuButton mock host
+// ---------------------------------------------------------------------------
+
+@Component({
+  standalone: false,
+  template: `
+    <button
+      usaHeaderSubmenu
+      [content]="submenuContent"
+      [isMegamenu]="isMegamenu"
+      [(selected)]="selected"
+      (selectedChange)="onSelectedChange($event)"
+    >
+      Submenu Button
+    </button>
+    <ng-template #submenuContent>
+      <li>Child 1</li>
+    </ng-template>
+  `,
+})
+class MockSubmenuHostComponent {
+  isMegamenu = false;
+  selected = false;
+  lastSelectedChange: boolean | null = null;
+
+  onSelectedChange(val: boolean) {
+    this.lastSelectedChange = val;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Original HeaderComponent suite (preserved, refactored to use helper)
+// ---------------------------------------------------------------------------
 
 describe('HeaderComponent', () => {
   let component: MockHeaderComponent;
@@ -99,66 +281,643 @@ describe('HeaderComponent', () => {
   });
 });
 
-@Component({
-  standalone: false,
-  template: `
-    <usa-header [extended]="extended" [primaryNavItems]="primaryNav" [secondaryNavItems]="secondaryNav"></usa-header>
-  `,
-})
-class MockHeaderComponent {
-  public extended = false;
+// ---------------------------------------------------------------------------
+// Title rendering
+// ---------------------------------------------------------------------------
 
-  constructor(public elementRef: ElementRef) {}
+describe('HeaderComponent – title input', () => {
+  it('renders a string title via the logo text element', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithStringTitleComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderWithStringTitleComponent);
+        fixture.detectChanges();
+        const logoText = fixture.debugElement.query(By.css('.usa-logo__text'));
+        expect(logoText).toBeTruthy();
+        expect(logoText.nativeElement.textContent.trim()).toContain('String Title');
+      });
+  }));
 
-  primaryNav: UsaHeaderPrimaryLink[] = [
-    {
-      text: 'Item 1',
-      id: 'item1',
-      href: '/item1',
-    },
-    {
-      text: 'Item 2',
-      id: 'item2',
-    },
-    {
-      text: 'Item 3',
-      id: 'item3',
-      children: [
-        {
-          text: 'item3Child1',
-          id: 'item3Child1',
-        },
-        {
-          text: 'item3Child2',
-          id: 'item3Child2',
-        },
-      ],
-    },
-    {
-      text: 'Item 4',
-      id: 'item4',
-      isMegamenu: true,
-      children: [
-        {
-          text: 'item4Child1',
-          id: 'item4Child1',
-        },
-        {
-          text: 'item4Child2',
-          id: 'item4Child2',
-        },
-      ],
-    },
-  ];
+  it('renders a TemplateRef title (getTypeOfTitle returns object)', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithTemplateTitleComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderWithTemplateTitleComponent);
+        fixture.detectChanges();
+        const customTitle = fixture.debugElement.query(By.css('#custom-title'));
+        expect(customTitle).toBeTruthy();
+        expect(customTitle.nativeElement.textContent.trim()).toContain('Custom Title');
+      });
+  }));
+});
 
-  secondaryNav: UsaNavigationLink[] = [
-    {
-      text: 'Secondary Item 1',
-      id: 'secondaryItem1',
-    },
-    {
-      text: 'Secondary Item 2',
-      id: 'secondaryItem2',
-    },
-  ];
-}
+// ---------------------------------------------------------------------------
+// menuButtonTemplate input
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – menuButtonTemplate input', () => {
+  it('renders default "Menu" text when no menuButtonTemplate is provided', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderComponent);
+        fixture.detectChanges();
+        const menuBtn = fixture.debugElement.query(By.css('.usa-menu-btn'));
+        expect(menuBtn.nativeElement.textContent).toContain('Menu');
+      });
+  }));
+
+  it('renders custom menuButtonTemplate when provided', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithMenuButtonTemplateComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderWithMenuButtonTemplateComponent);
+        fixture.detectChanges();
+        const customMenu = fixture.debugElement.query(By.css('#custom-menu-btn'));
+        expect(customMenu).toBeTruthy();
+        expect(customMenu.nativeElement.textContent.trim()).toContain('Custom Menu');
+      });
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// navAriaLabel input
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – navAriaLabel input', () => {
+  it('uses default nav aria label "Primary Navigation"', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderComponent);
+        fixture.detectChanges();
+        const nav = fixture.debugElement.query(By.css('nav.usa-nav'));
+        expect(nav.attributes['aria-label']).toEqual('Primary Navigation');
+      });
+  }));
+
+  it('uses custom navAriaLabel when provided', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithNavAriaLabelComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderWithNavAriaLabelComponent);
+        fixture.detectChanges();
+        const nav = fixture.debugElement.query(By.css('nav.usa-nav'));
+        expect(nav.attributes['aria-label']).toEqual('My Custom Nav Label');
+      });
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// displayOverlayOnMenuOpen input
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – displayOverlayOnMenuOpen', () => {
+  let fixture: ComponentFixture<MockHeaderWithOverlayComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithOverlayComponent],
+      imports: [UsaHeaderModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockHeaderWithOverlayComponent);
+    fixture.detectChanges();
+  });
+
+  it('overlay is not visible when no dropdown is open', () => {
+    const overlay = fixture.debugElement.query(By.css('.usa-overlay'));
+    expect(overlay.classes['is-visible']).toBeFalsy();
+  });
+
+  it('overlay becomes visible when a dropdown is opened', () => {
+    const dropdownBtn = fixture.debugElement.query(By.css('#item3'));
+    dropdownBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    const overlay = fixture.debugElement.query(By.css('.usa-overlay'));
+    expect(overlay.classes['is-visible']).toBe(true);
+  });
+
+  it('overlay hides again when the same dropdown is closed', () => {
+    const dropdownBtn = fixture.debugElement.query(By.css('#item3'));
+    // open
+    dropdownBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+    // close
+    dropdownBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    const overlay = fixture.debugElement.query(By.css('.usa-overlay'));
+    expect(overlay.classes['is-visible']).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile nav open / close
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – mobile nav', () => {
+  let fixture: ComponentFixture<MockHeaderComponent>;
+  let headerDE: any;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockHeaderComponent);
+    fixture.detectChanges();
+    headerDE = fixture.debugElement.query(By.directive(UsaHeaderComponent));
+  });
+
+  it('mobileNavActive is false by default', () => {
+    const header = headerDE.componentInstance as UsaHeaderComponent;
+    expect(header.mobileNavActive).toBe(false);
+  });
+
+  it('clicking the menu button sets mobileNavActive to true and adds is-visible to nav', () => {
+    const menuBtn = fixture.debugElement.query(By.css('.usa-menu-btn'));
+    menuBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    const header = headerDE.componentInstance as UsaHeaderComponent;
+    expect(header.mobileNavActive).toBe(true);
+
+    const nav = fixture.debugElement.query(By.css('nav.usa-nav'));
+    expect(nav.classes['is-visible']).toBe(true);
+  });
+
+  it('clicking the close button sets mobileNavActive to false', () => {
+    const header = headerDE.componentInstance as UsaHeaderComponent;
+    // Open first
+    header.openMobileNav();
+    fixture.detectChanges();
+
+    // Stub focus so we don't blow up on jsdom
+    const openBtnEl = headerDE.query(By.css('.usa-menu-btn')).nativeElement;
+    openBtnEl.focus = () => {};
+
+    const closeBtn = fixture.debugElement.query(By.css('.usa-nav__close'));
+    closeBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    expect(header.mobileNavActive).toBe(false);
+  });
+
+  it('pressing Escape in nav closes mobile nav', () => {
+    const header = headerDE.componentInstance as UsaHeaderComponent;
+    header.openMobileNav();
+    fixture.detectChanges();
+
+    // Stub focus
+    (header as any).openNavBtn = { nativeElement: { focus: () => {} } };
+
+    const nav = fixture.debugElement.query(By.css('nav.usa-nav'));
+    nav.triggerEventHandler('keydown.esc', null);
+    fixture.detectChanges();
+
+    expect(header.mobileNavActive).toBe(false);
+  });
+
+  it('onBrowserResize closes mobile nav when close button width is 0', () => {
+    const header = headerDE.componentInstance as UsaHeaderComponent;
+    header.openMobileNav();
+    fixture.detectChanges();
+
+    // Simulate the close button having zero width (viewport resized to desktop)
+    (header as any).closeNavBtn = {
+      nativeElement: { getBoundingClientRect: () => ({ width: 0 }) },
+    };
+
+    header.onBrowserResize({});
+    expect(header.mobileNavActive).toBe(false);
+  });
+
+  it('onBrowserResize does not close mobile nav when close button is still visible', () => {
+    const header = headerDE.componentInstance as UsaHeaderComponent;
+    header.openMobileNav();
+    fixture.detectChanges();
+
+    (header as any).closeNavBtn = {
+      nativeElement: { getBoundingClientRect: () => ({ width: 40 }) },
+    };
+
+    header.onBrowserResize({});
+    expect(header.mobileNavActive).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// navAnimationEnd
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – navAnimationEnd', () => {
+  it('focuses the close button when animation ends', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderComponent);
+        fixture.detectChanges();
+
+        const headerDE = fixture.debugElement.query(By.directive(UsaHeaderComponent));
+        const header = headerDE.componentInstance as UsaHeaderComponent;
+
+        let focused = false;
+        (header as any).closeNavBtn = {
+          nativeElement: {
+            focus: () => {
+              focused = true;
+            },
+          },
+        };
+
+        header.navAnimationEnd();
+        expect(focused).toBe(true);
+      });
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// documentClick clears selectedDropdownLink
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – documentClick', () => {
+  it('clears selectedDropdownLink on document click', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderComponent);
+        fixture.detectChanges();
+
+        const headerDE = fixture.debugElement.query(By.directive(UsaHeaderComponent));
+        const header = headerDE.componentInstance as UsaHeaderComponent;
+
+        // Open a dropdown first
+        const dropdownBtn = fixture.debugElement.query(By.css('#item3'));
+        dropdownBtn.triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(header.selectedDropdownLink).toBeTruthy();
+
+        // Simulate document click
+        header.documentClick({});
+        fixture.detectChanges();
+        expect(header.selectedDropdownLink).toBeNull();
+      });
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// removeWhiteSpace
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – removeWhiteSpace', () => {
+  it('removes all spaces from a string', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderComponent);
+        fixture.detectChanges();
+        const headerDE = fixture.debugElement.query(By.directive(UsaHeaderComponent));
+        const header = headerDE.componentInstance as UsaHeaderComponent;
+        expect(header.removeWhiteSpace('hello world foo')).toEqual('helloworldfoo');
+        expect(header.removeWhiteSpace('noSpaces')).toEqual('noSpaces');
+      });
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// selectNavItem and linkClickEvent
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – selectNavItem and linkClickEvent', () => {
+  let fixture: ComponentFixture<MockHeaderWithLinkEventComponent>;
+  let header: UsaHeaderComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithLinkEventComponent],
+      imports: [UsaHeaderModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockHeaderWithLinkEventComponent);
+    fixture.detectChanges();
+    header = fixture.debugElement.query(By.directive(UsaHeaderComponent)).componentInstance as UsaHeaderComponent;
+  });
+
+  it('selectNavItem marks the item selected and deselects previous', () => {
+    const nav1: UsaNavigationLink = { text: 'A', id: 'a' };
+    const nav2: UsaNavigationLink = { text: 'B', id: 'b' };
+
+    header.selectNavItem(nav1);
+    expect(nav1.selected).toBe(true);
+    expect(header.selectedNavItem).toBe(nav1);
+
+    header.selectNavItem(nav2);
+    expect(nav1.selected).toBe(false);
+    expect(nav2.selected).toBe(true);
+    expect(header.selectedNavItem).toBe(nav2);
+  });
+
+  it('linkClickEvent emits the link and selects it', () => {
+    const link: UsaNavigationLink = { text: 'Link', id: 'link1' };
+    header.linkClickEvent(link);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.lastEvent).toBe(link);
+    expect(link.selected).toBe(true);
+  });
+
+  it('linkClickEvent with parentNav selects the parentNav, emits the child link', () => {
+    const parent: UsaNavigationLink = { text: 'Parent', id: 'parent1' };
+    const child: UsaNavigationLink = { text: 'Child', id: 'child1' };
+
+    header.linkClickEvent(child, parent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.lastEvent).toBe(child);
+    expect(parent.selected).toBe(true);
+    expect(header.selectedNavItem).toBe(parent);
+  });
+
+  it('clicking a plain (non-dropdown) link emits linkEvent', () => {
+    const linkEl = fixture.debugElement.query(By.css('#item2'));
+    linkEl.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.lastEvent).toBeTruthy();
+    expect((fixture.componentInstance.lastEvent as UsaNavigationLink).id).toEqual('item2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ngOnInit: pre-selected nav items
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – ngOnInit pre-selected nav items', () => {
+  it('keeps the first selected item and deselects the rest', waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderWithSelectedNavComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(MockHeaderWithSelectedNavComponent);
+        fixture.detectChanges();
+
+        const header = fixture.debugElement.query(By.directive(UsaHeaderComponent))
+          .componentInstance as UsaHeaderComponent;
+
+        // First item had selected:true → should be the selectedNavItem
+        expect(header.selectedNavItem).toBeTruthy();
+        expect(header.selectedNavItem!.id).toEqual('item1');
+
+        // Second item had selected:true but should be cleared since first was already selected
+        const nav = fixture.componentInstance.primaryNav;
+        expect(nav[1].selected).toBe(false);
+      });
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// dropdownLinkClicked: toggling the same link closes it
+// ---------------------------------------------------------------------------
+
+describe('HeaderComponent – dropdownLinkClicked toggle', () => {
+  let fixture: ComponentFixture<MockHeaderComponent>;
+  let header: UsaHeaderComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockHeaderComponent],
+      imports: [UsaHeaderModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockHeaderComponent);
+    fixture.detectChanges();
+    header = fixture.debugElement.query(By.directive(UsaHeaderComponent)).componentInstance as UsaHeaderComponent;
+  });
+
+  it('clicking the already-open dropdown closes it (selectedDropdownLink becomes null)', () => {
+    const dropdownBtn = fixture.debugElement.query(By.css('#item3'));
+
+    // open
+    dropdownBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+    expect(header.selectedDropdownLink).toBeTruthy();
+
+    // click the same button again → should close
+    dropdownBtn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+    expect(header.selectedDropdownLink).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UsaHeaderSubmenuButton
+// ---------------------------------------------------------------------------
+
+describe('UsaHeaderSubmenuButton', () => {
+  let fixture: ComponentFixture<MockSubmenuHostComponent>;
+  let host: MockSubmenuHostComponent;
+  let buttonDE: any;
+  let button: UsaHeaderSubmenuButton;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockSubmenuHostComponent],
+      imports: [UsaHeaderModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockSubmenuHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    buttonDE = fixture.debugElement.query(By.directive(UsaHeaderSubmenuButton));
+    button = buttonDE.componentInstance as UsaHeaderSubmenuButton;
+  });
+
+  it('should create', () => {
+    expect(button).toBeTruthy();
+  });
+
+  it('is closed (aria-expanded false) by default', () => {
+    expect(buttonDE.attributes['aria-expanded']).toEqual('false');
+  });
+
+  it('onClick opens the submenu and emits selectedChange true', () => {
+    button.onClick();
+    fixture.detectChanges();
+
+    expect(button.selected).toBe(true);
+    expect(host.lastSelectedChange).toBe(true);
+    expect(buttonDE.attributes['aria-expanded']).toEqual('true');
+  });
+
+  it('onClick twice closes the submenu and emits selectedChange false', () => {
+    button.onClick(); // open
+    fixture.detectChanges();
+    button.onClick(); // close
+    fixture.detectChanges();
+
+    expect(button.selected).toBe(false);
+    expect(host.lastSelectedChange).toBe(false);
+  });
+
+  it('document click outside closes an open submenu', () => {
+    button.onClick(); // open
+    fixture.detectChanges();
+    expect(button.selected).toBe(true);
+
+    // Simulate a click outside by dispatching on document
+    const outsideClick = new MouseEvent('click', { bubbles: true });
+    document.dispatchEvent(outsideClick);
+    fixture.detectChanges();
+
+    expect(button.selected).toBe(false);
+  });
+
+  it('document click inside the button does NOT close the submenu', () => {
+    button.onClick(); // open
+    fixture.detectChanges();
+
+    // Click inside the button element itself
+    buttonDE.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.detectChanges();
+
+    // The button's own click opens/closes (onClick fires), so check it still reflects toggle
+    // The key behavior: onDocumentClick should not additionally close it (it returns early)
+    // After onClick (open) + click inside = toggles to closed via onClick, not onDocumentClick
+    // So we just confirm onDocumentClick guard works — selected will be toggled by onClick
+    expect(button.selected).toBeDefined();
+  });
+
+  it('onDocumentClick is a no-op when submenu is already closed', () => {
+    expect(button.selected).toBe(false);
+    // dispatching document click when closed should not throw or change state
+    const outsideClick = new MouseEvent('click', { bubbles: true });
+    document.dispatchEvent(outsideClick);
+    fixture.detectChanges();
+    expect(button.selected).toBe(false);
+  });
+
+  it('isMegamenu default is false', () => {
+    expect(button.isMegamenu).toBe(false);
+  });
+
+  it('renders submenu content when open', () => {
+    button.onClick();
+    fixture.detectChanges();
+    const submenu = fixture.debugElement.query(By.css('.usa-nav__submenu'));
+    expect(submenu).toBeTruthy();
+  });
+
+  it('does not render submenu content when closed', () => {
+    // starts closed
+    const submenu = fixture.debugElement.query(By.css('.usa-nav__submenu'));
+    expect(submenu).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UsaHeaderPrimaryLinkTemplate and UsaHeaderSecondaryLinkTemplate directives
+// ---------------------------------------------------------------------------
+
+describe('UsaHeaderPrimaryLinkTemplate directive', () => {
+  it('exposes templateRef from constructor injection', waitForAsync(() => {
+    @Component({
+      standalone: false,
+      template: `
+        <usa-header [primaryNavItems]="primaryNav">
+          <ng-template usaHeaderPrimaryLinkTemplate let-link>
+            <span class="custom-primary-link">{{ link.text }}</span>
+          </ng-template>
+        </usa-header>
+      `,
+    })
+    class HostComponent {
+      primaryNav: UsaHeaderPrimaryLink[] = [{ text: 'Custom Item', id: 'ci1' }];
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        const links = fixture.debugElement.queryAll(By.css('.custom-primary-link'));
+        expect(links.length).toBeGreaterThan(0);
+        expect(links[0].nativeElement.textContent.trim()).toContain('Custom Item');
+      });
+  }));
+});
+
+describe('UsaHeaderSecondaryLinkTemplate directive', () => {
+  it('exposes templateRef and renders custom secondary links', waitForAsync(() => {
+    @Component({
+      standalone: false,
+      template: `
+        <usa-header [extended]="true" [primaryNavItems]="primaryNav" [secondaryNavItems]="secondaryNav">
+          <ng-template usaHeaderSecondaryLinkTemplate let-link>
+            <span class="custom-secondary-link">{{ link.text }}</span>
+          </ng-template>
+        </usa-header>
+      `,
+    })
+    class HostComponent {
+      primaryNav: UsaHeaderPrimaryLink[] = makePrimaryNav();
+      secondaryNav: UsaNavigationLink[] = makeSecondaryNav();
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [UsaHeaderModule],
+    })
+      .compileComponents()
+      .then(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        const links = fixture.debugElement.queryAll(By.css('.custom-secondary-link'));
+        expect(links.length).toBe(2);
+      });
+  }));
+});

--- a/projects/uswds-components/src/lib/header/header.component.spec.ts
+++ b/projects/uswds-components/src/lib/header/header.component.spec.ts
@@ -1,11 +1,10 @@
-import { Component, ElementRef, TemplateRef, ViewChild } from '@angular/core';
+import { Component, ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { UsaNavigationLink } from '../util/navigation';
 import { UsaHeaderPrimaryLink } from './header.model';
 import { UsaHeaderModule } from './header.module';
 import { UsaHeaderComponent } from './header.component';
-import { UsaHeaderPrimaryLinkTemplate, UsaHeaderSecondaryLinkTemplate } from './header-selectors';
 import { UsaHeaderSubmenuButton } from './header-submenu.component';
 
 // ---------------------------------------------------------------------------
@@ -817,16 +816,14 @@ describe('UsaHeaderSubmenuButton', () => {
   it('document click inside the button does NOT close the submenu', () => {
     button.onClick(); // open
     fixture.detectChanges();
+    expect(button.selected).toBe(true);
 
-    // Click inside the button element itself
-    buttonDE.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    // Call onDocumentClick directly with a target *inside* the button element.
+    // The guard should return early, leaving the submenu open.
+    button.onDocumentClick({ target: buttonDE.nativeElement });
     fixture.detectChanges();
 
-    // The button's own click opens/closes (onClick fires), so check it still reflects toggle
-    // The key behavior: onDocumentClick should not additionally close it (it returns early)
-    // After onClick (open) + click inside = toggles to closed via onClick, not onDocumentClick
-    // So we just confirm onDocumentClick guard works — selected will be toggled by onClick
-    expect(button.selected).toBeDefined();
+    expect(button.selected).toBe(true);
   });
 
   it('onDocumentClick is a no-op when submenu is already closed', () => {


### PR DESCRIPTION
## Description

Extends `header.component.spec.ts` to cover the previously untested paths across all four header source files:

**`header.component.ts`** (82% → 100% statements, 46% → 100% functions, 54% → 96% branches):
- `title` input as `TemplateRef` (`getTypeOfTitle` object branch)
- `menuButtonTemplate` custom template rendering (and default "Menu" fallback)
- `navAriaLabel` default and custom values
- `displayOverlayOnMenuOpen` overlay visibility toggle (open, close)
- `openMobileNav()` / `closeMobileNav()` — `mobileNavActive` toggle and focus return
- `navAnimationEnd()` — focuses the close button
- `onBrowserResize()` — closes mobile nav when close btn width is 0; no-op when still visible
- `documentClick()` — clears `selectedDropdownLink`
- `removeWhiteSpace()` — strips all spaces
- `selectNavItem()` — marks item selected, deselects previous
- `linkClickEvent()` — emits `linkEvent` with and without `parentNav`
- `ngOnInit` with pre-selected nav items — first selected wins, rest cleared
- `dropdownLinkClicked` toggle-closed path (clicking open dropdown again)

**`header-submenu.component.ts`** (0% → 100% functions):
- `onClick()` open/close toggle and `selectedChange` emission
- `attachContent()` / `detachContent()` via `onClick`
- `onDocumentClick()` — closes on outside click, no-op on inside click, no-op when already closed

**`header-selectors.ts`** (0% → 100% branches and functions):
- `UsaHeaderPrimaryLinkTemplate` — directive instantiation and `templateRef` rendering
- `UsaHeaderSecondaryLinkTemplate` — directive instantiation and `templateRef` rendering

## Motivation and Context

Closes #245

Part of the #237 coverage improvement effort. The header component was sitting at ~43% coverage; this PR brings all four header files to ≥96% statements/branches/functions/lines without editing the coverage gate or floor file.

## Type of Change (Select One and Apply Label)

- [ ] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [ ] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [ ] Documentation / configuration update → Apply `documentation` label
- [x] Maintenance / test coverage → Apply `maintenance` label

## How to Test

1. `npm run test:components` — all 362 tests pass (326 existing + 36 new)
2. `npm run coverage:check` — gate passes at all four metrics above floor
3. Inspect per-file coverage for `header.component.ts`, `header-submenu.component.ts`, and `header-selectors.ts` to confirm the gains

**Expected result:**
```
Statements   : 90.69% (floor 81%) ✓
Branches     : 92.50% (floor 83%) ✓
Functions    : 74.09% (floor 48%) ✓
Lines        : 90.69% (floor 81%) ✓
```

Header-file breakdown:
| File | Statements | Branches | Functions |
|---|---|---|---|
| `header.component.ts` | 100% | 96% | 100% |
| `header-submenu.component.ts` | 100% | 100% | 100% |
| `header-selectors.ts` | 100% | 100% | 100% |

## Screenshots (if appropriate)

N/A — test-only change, no UI modifications.

## Checklist

- [x] Branch name follows convention (`gh-245-coverage-header-to-90`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [ ] `lint` passes (`npm run lint`) — no `lint` target configured in this workspace (see AGENTS.md)
- [ ] `build-prod` passes (`npm run build-prod`) — test-only change, no source changes
- [x] Tests pass and coverage is reported (`npm run test:components` + `npm run coverage:check`)
- [x] If this change requires a documentation update, I have updated it accordingly — N/A
- [ ] If there are dependent changes, they have been merged and published in downstream modules — N/A
