### PR TITLE
Add unit specs for breadcrumb, button-group, dropdown, and sidenav

### DIFF
--- a/projects/uswds-components/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/uswds-components/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -114,8 +114,8 @@ describe('UsaBreadcrumbComponent', () => {
     expect(currentEl.nativeElement.textContent.trim()).toBe('Item 1');
   });
 
-  it('renders the correct number of non-current breadcrumbs', () => {
-    // 3 items → 2 displayed crumbs + 1 current
+  it('renders the correct number of breadcrumb list items (including current)', () => {
+    // 3 items → 2 displayed crumbs + 1 current = 3 total list items
     const listItems = fixture.debugElement.queryAll(By.css('.usa-breadcrumb__list-item'));
     expect(listItems.length).toBe(3);
   });

--- a/projects/uswds-components/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/uswds-components/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,188 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { UsaBreadcrumbModule } from './breadcrumb.module';
+import { UsaNavigationLink, UsaNavigationMode } from '../util/navigation';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeItems(count: number): UsaNavigationLink[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `item-${i}`,
+    text: `Item ${i}`,
+    mode: UsaNavigationMode.EVENT,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Host components
+// ---------------------------------------------------------------------------
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-breadcrumb
+      [items]="items"
+      [wrap]="wrap"
+      [hideSingleCrumb]="hideSingleCrumb"
+      (selected)="onSelected($event)"
+    ></usa-breadcrumb>
+  `,
+})
+class HostComponent {
+  items: UsaNavigationLink[] = makeItems(3);
+  wrap = false;
+  hideSingleCrumb = false;
+  lastSelected: UsaNavigationLink | null = null;
+  onSelected(item: UsaNavigationLink) {
+    this.lastSelected = item;
+  }
+}
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-breadcrumb [items]="items">
+      <a *usaBreadcrumbLinkTemplate="let bc" class="custom-link" href="#">{{ bc.text }}</a>
+    </usa-breadcrumb>
+  `,
+})
+class CustomTemplateHostComponent {
+  items: UsaNavigationLink[] = makeItems(3);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UsaBreadcrumbComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent, CustomTemplateHostComponent],
+      imports: [UsaBreadcrumbModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the breadcrumb component', () => {
+    const bc = fixture.debugElement.query(By.css('usa-breadcrumb'));
+    expect(bc).toBeTruthy();
+  });
+
+  it('renders the nav element when items are provided', () => {
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav).toBeTruthy();
+  });
+
+  it('hides the nav when items array is empty', () => {
+    host.items = [];
+    fixture.detectChanges();
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav).toBeNull();
+  });
+
+  it('hides the nav when items is null', () => {
+    host.items = null as any;
+    fixture.detectChanges();
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav).toBeNull();
+  });
+
+  it('auto-selects the last item when none is pre-selected', () => {
+    const items = makeItems(3);
+    host.items = items;
+    fixture.detectChanges();
+    expect(items[2].selected).toBe(true);
+  });
+
+  it('respects a pre-selected item in the middle', () => {
+    const items = makeItems(4);
+    items[1].selected = true;
+    host.items = items;
+    fixture.detectChanges();
+    const currentEl = fixture.debugElement.query(By.css('.usa-current span'));
+    expect(currentEl.nativeElement.textContent.trim()).toBe('Item 1');
+  });
+
+  it('renders the correct number of non-current breadcrumbs', () => {
+    // 3 items → 2 displayed crumbs + 1 current
+    const listItems = fixture.debugElement.queryAll(By.css('.usa-breadcrumb__list-item'));
+    expect(listItems.length).toBe(3);
+  });
+
+  it('adds usa-breadcrumb--wrap class when wrap is true', () => {
+    host.wrap = true;
+    fixture.detectChanges();
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav.nativeElement.classList).toContain('usa-breadcrumb--wrap');
+  });
+
+  it('does not add wrap class when wrap is false', () => {
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav.nativeElement.classList).not.toContain('usa-breadcrumb--wrap');
+  });
+
+  it('hides breadcrumb when hideSingleCrumb is true and only one item', () => {
+    host.items = makeItems(1);
+    host.hideSingleCrumb = true;
+    fixture.detectChanges();
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav).toBeNull();
+  });
+
+  it('shows breadcrumb when hideSingleCrumb is true but multiple items', () => {
+    host.hideSingleCrumb = true;
+    fixture.detectChanges();
+    const nav = fixture.debugElement.query(By.css('nav.usa-breadcrumb'));
+    expect(nav).toBeTruthy();
+  });
+
+  it('emits selected event when updateSelectedBreadcrumb is called', () => {
+    const bcDe = fixture.debugElement.query(By.css('usa-breadcrumb'));
+    const bcComp = bcDe.componentInstance;
+    // _selectedBreadcrumb is the last item; click on the first displayed crumb
+    const target = host.items[0];
+    bcComp._selectedBreadcrumb = host.items[2];
+    bcComp.updateSelectedBreadcrumb(target);
+    fixture.detectChanges();
+    expect(host.lastSelected).toBe(target);
+  });
+
+  it('ngOnChanges updates crumbs when items change', () => {
+    const newItems = makeItems(5);
+    host.items = newItems;
+    fixture.detectChanges();
+    const listItems = fixture.debugElement.queryAll(By.css('.usa-breadcrumb__list-item'));
+    // 4 displayed + 1 current = 5
+    expect(listItems.length).toBe(5);
+  });
+
+  it('ngOnChanges updates crumbs when hideSingleCrumb changes', () => {
+    host.items = makeItems(1);
+    fixture.detectChanges();
+    // Currently showing (hideSingleCrumb false)
+    expect(fixture.debugElement.query(By.css('nav.usa-breadcrumb'))).toBeTruthy();
+
+    host.hideSingleCrumb = true;
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('nav.usa-breadcrumb'))).toBeNull();
+  });
+
+  it('renders custom link template when provided', () => {
+    const customFixture = TestBed.createComponent(CustomTemplateHostComponent);
+    customFixture.detectChanges();
+    const customLinks = customFixture.debugElement.queryAll(By.css('a.custom-link'));
+    // 3 items → 2 non-current displayed crumbs get the template
+    expect(customLinks.length).toBe(2);
+  });
+});

--- a/projects/uswds-components/src/lib/button-group/button-group.component.spec.ts
+++ b/projects/uswds-components/src/lib/button-group/button-group.component.spec.ts
@@ -1,0 +1,107 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { USWDSButtonGroupModule } from './button-group.module';
+
+// ---------------------------------------------------------------------------
+// Host components
+// ---------------------------------------------------------------------------
+
+@Component({
+  standalone: false,
+  template: `
+    <uswds-button-group [isSegmented]="isSegmented">
+      <uswds-button-group-item><button>One</button></uswds-button-group-item>
+      <uswds-button-group-item><button>Two</button></uswds-button-group-item>
+    </uswds-button-group>
+  `,
+})
+class HostComponent {
+  isSegmented = false;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('USWDSButtonGroupComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [USWDSButtonGroupModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the button group', () => {
+    const el = fixture.debugElement.query(By.css('uswds-button-group'));
+    expect(el).toBeTruthy();
+  });
+
+  it('renders a <ul> with class usa-button-group', () => {
+    const ul = fixture.debugElement.query(By.css('ul.usa-button-group'));
+    expect(ul).toBeTruthy();
+  });
+
+  it('does not have segmented class by default', () => {
+    const ul = fixture.debugElement.query(By.css('ul.usa-button-group'));
+    expect(ul.nativeElement.classList).not.toContain('usa-button-group--segmented');
+  });
+
+  it('adds segmented class when isSegmented is true', () => {
+    host.isSegmented = true;
+    fixture.detectChanges();
+    const ul = fixture.debugElement.query(By.css('ul.usa-button-group'));
+    expect(ul.nativeElement.classList).toContain('usa-button-group--segmented');
+  });
+
+  it('removes segmented class when isSegmented is toggled back to false', () => {
+    host.isSegmented = true;
+    fixture.detectChanges();
+    host.isSegmented = false;
+    fixture.detectChanges();
+    const ul = fixture.debugElement.query(By.css('ul.usa-button-group'));
+    expect(ul.nativeElement.classList).not.toContain('usa-button-group--segmented');
+  });
+
+  it('projects button-group-item children', () => {
+    const items = fixture.debugElement.queryAll(By.css('uswds-button-group-item'));
+    expect(items.length).toBe(2);
+  });
+});
+
+describe('USWDSButtonGroupItemComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [USWDSButtonGroupModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('applies usa-button-group__item host class', () => {
+    const items = fixture.debugElement.queryAll(By.css('uswds-button-group-item'));
+    items.forEach((item) => {
+      expect(item.nativeElement.classList).toContain('usa-button-group__item');
+    });
+  });
+
+  it('projects button content', () => {
+    const buttons = fixture.debugElement.queryAll(By.css('uswds-button-group-item button'));
+    expect(buttons.length).toBe(2);
+  });
+});

--- a/projects/uswds-components/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/uswds-components/src/lib/dropdown/dropdown.component.spec.ts
@@ -1,0 +1,163 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { UsaDropdownModule } from './dropdown.module';
+import { DropdownOptionsModel } from './dropdown-options.model';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const OPTIONS: DropdownOptionsModel[] = [
+  { label: 'Option A', value: 'a' },
+  { label: 'Option B', value: 'b' },
+  { label: 'Option C', value: 'c', disabled: true },
+];
+
+// ---------------------------------------------------------------------------
+// Host components
+// ---------------------------------------------------------------------------
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-dropdown
+      [options]="options"
+      [id]="id"
+      [name]="name"
+      [disabled]="disabled"
+      (optionChange)="onOptionChange($event)"
+    ></usa-dropdown>
+  `,
+})
+class HostComponent {
+  options: DropdownOptionsModel[] = OPTIONS;
+  id = 'test-dropdown';
+  name = 'test-name';
+  disabled = false;
+  lastChange: DropdownOptionsModel | null = null;
+  onOptionChange(opt: DropdownOptionsModel) {
+    this.lastChange = opt;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UsaDropdownComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [UsaDropdownModule, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the dropdown', () => {
+    const el = fixture.debugElement.query(By.css('usa-dropdown'));
+    expect(el).toBeTruthy();
+  });
+
+  it('renders a <select> element', () => {
+    const select = fixture.debugElement.query(By.css('select.usa-select'));
+    expect(select).toBeTruthy();
+  });
+
+  it('applies the id input to the select', () => {
+    const select = fixture.debugElement.query(By.css('select'));
+    expect(select.nativeElement.id).toBe('test-dropdown');
+  });
+
+  it('applies the name input to the select', () => {
+    const select = fixture.debugElement.query(By.css('select'));
+    expect(select.nativeElement.name).toBe('test-name');
+  });
+
+  it('renders the correct number of options', () => {
+    const opts = fixture.debugElement.queryAll(By.css('option'));
+    expect(opts.length).toBe(3);
+  });
+
+  it('renders option labels', () => {
+    const opts = fixture.debugElement.queryAll(By.css('option'));
+    expect(opts[0].nativeElement.textContent.trim()).toBe('Option A');
+    expect(opts[1].nativeElement.textContent.trim()).toBe('Option B');
+  });
+
+  it('marks a disabled option as disabled', () => {
+    const opts = fixture.debugElement.queryAll(By.css('option'));
+    expect(opts[2].nativeElement.disabled).toBe(true);
+  });
+
+  it('is not disabled by default', () => {
+    const select = fixture.debugElement.query(By.css('select'));
+    expect(select.nativeElement.disabled).toBe(false);
+  });
+
+  it('disables the select when disabled input is true', () => {
+    host.disabled = true;
+    fixture.detectChanges();
+    const select = fixture.debugElement.query(By.css('select'));
+    expect(select.nativeElement.disabled).toBe(true);
+  });
+
+  it('emits optionChange when a new option is selected', () => {
+    const dropdownComp = fixture.debugElement.query(By.css('usa-dropdown')).componentInstance;
+    const select = fixture.debugElement.query(By.css('select')).nativeElement;
+
+    // Simulate selecting option B (index 1)
+    select.selectedIndex = 1;
+    const mockEvent = {
+      target: {
+        options: select.options,
+        selectedIndex: 1,
+      },
+    };
+    dropdownComp.onOptionSelected(mockEvent);
+    fixture.detectChanges();
+
+    expect(host.lastChange).toEqual({ label: 'Option B', value: 'b' });
+  });
+
+  it('writeValue sets the model and marks for check', () => {
+    const dropdownComp = fixture.debugElement.query(By.css('usa-dropdown')).componentInstance;
+    const value: DropdownOptionsModel = { label: 'Option A', value: 'a' };
+    dropdownComp.writeValue(value);
+    expect(dropdownComp.model).toEqual(value);
+  });
+
+  it('registerOnChange stores the callback', () => {
+    const dropdownComp = fixture.debugElement.query(By.css('usa-dropdown')).componentInstance;
+    const fn = vi.fn();
+    dropdownComp.registerOnChange(fn);
+    // trigger via onOptionSelected
+    const select = fixture.debugElement.query(By.css('select')).nativeElement;
+    select.selectedIndex = 0;
+    dropdownComp.onOptionSelected({ target: { options: select.options, selectedIndex: 0 } });
+    expect(fn).toHaveBeenCalledWith({ label: 'Option A', value: 'a' });
+  });
+
+  it('registerOnTouched stores the callback', () => {
+    const dropdownComp = fixture.debugElement.query(By.css('usa-dropdown')).componentInstance;
+    const fn = vi.fn();
+    dropdownComp.registerOnTouched(fn);
+    expect(typeof dropdownComp['onTouched']).toBe('function');
+  });
+
+  it('auto-generates a unique id matching the pattern', () => {
+    // Directly instantiate the component class to check the default
+    const { UsaDropdownComponent } = require('./dropdown.component');
+    const comp = new UsaDropdownComponent({ markForCheck: () => {} } as any);
+    expect(comp.id).toMatch(/^usa-dropdown-\d+$/);
+  });
+});

--- a/projects/uswds-components/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/uswds-components/src/lib/dropdown/dropdown.component.spec.ts
@@ -4,6 +4,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { UsaDropdownModule } from './dropdown.module';
 import { DropdownOptionsModel } from './dropdown-options.model';
+import { UsaDropdownComponent } from './dropdown.component';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -129,11 +130,13 @@ describe('UsaDropdownComponent', () => {
     expect(host.lastChange).toEqual({ label: 'Option B', value: 'b' });
   });
 
-  it('writeValue sets the model and marks for check', () => {
+  it('writeValue sets the model and calls markForCheck on the ChangeDetectorRef', () => {
     const dropdownComp = fixture.debugElement.query(By.css('usa-dropdown')).componentInstance;
+    const markForCheckSpy = vi.spyOn(dropdownComp.cdr, 'markForCheck');
     const value: DropdownOptionsModel = { label: 'Option A', value: 'a' };
     dropdownComp.writeValue(value);
     expect(dropdownComp.model).toEqual(value);
+    expect(markForCheckSpy).toHaveBeenCalled();
   });
 
   it('registerOnChange stores the callback', () => {
@@ -147,17 +150,19 @@ describe('UsaDropdownComponent', () => {
     expect(fn).toHaveBeenCalledWith({ label: 'Option A', value: 'a' });
   });
 
-  it('registerOnTouched stores the callback', () => {
+  it('registerOnTouched stores the callback and calls it when the select is blurred', () => {
     const dropdownComp = fixture.debugElement.query(By.css('usa-dropdown')).componentInstance;
     const fn = vi.fn();
     dropdownComp.registerOnTouched(fn);
-    expect(typeof dropdownComp['onTouched']).toBe('function');
+    // onTouched should now be the spy; call it to verify the reference was stored
+    dropdownComp['onTouched']();
+    expect(fn).toHaveBeenCalled();
   });
 
   it('auto-generates a unique id matching the pattern', () => {
-    // Directly instantiate the component class to check the default
-    const { UsaDropdownComponent } = require('./dropdown.component');
-    const comp = new UsaDropdownComponent({ markForCheck: () => {} } as any);
+    // Each new component instance gets an auto-incremented id; verify the default shape.
+    const cdrStub = { markForCheck: () => {} } as any;
+    const comp = new UsaDropdownComponent(cdrStub);
     expect(comp.id).toMatch(/^usa-dropdown-\d+$/);
   });
 });

--- a/projects/uswds-components/src/lib/sidenav/sidenav.component.spec.ts
+++ b/projects/uswds-components/src/lib/sidenav/sidenav.component.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import { UsaSidenavModule } from './sidenav.module';
 import { SidenavModel } from './sidenav.model';
 import { UsaNavigationMode } from '../util/navigation';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -78,7 +78,7 @@ describe('UsaSidenavComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [HostComponent],
-      imports: [UsaSidenavModule, RouterModule.forRoot([])],
+      imports: [UsaSidenavModule, RouterTestingModule],
     }).compileComponents();
   }));
 
@@ -222,7 +222,8 @@ describe('UsaSidenavComponent', () => {
     fixture.detectChanges();
 
     const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
-    // single expand-type: collapsed was set true in ngOnInit
+    // host.items was just set above, but the fixture was already created with the original
+    // makeLinks(3) items, so ngOnInit already ran. Record the current collapsed state.
     const collapsedBefore = host.items[0].collapsed;
     sidenavComp.expandAll();
     expect(host.items[0].collapsed).toBe(collapsedBefore);
@@ -285,10 +286,7 @@ describe('UsaSidenavComponent', () => {
         children: [{ id: 'a1', text: 'A1', mode: UsaNavigationMode.EVENT }],
       },
     ];
-    // Re-create component so ngOnInit fires with these inputs
-    host.items = items;
-    host.expandType = 'single';
-    // Destroy and re-create the fixture to trigger ngOnInit fresh
+    // A fresh fixture ensures ngOnInit fires with expandType set from the start.
     const f2 = TestBed.createComponent(HostComponent);
     f2.componentInstance.items = items;
     f2.componentInstance.expandType = 'single';

--- a/projects/uswds-components/src/lib/sidenav/sidenav.component.spec.ts
+++ b/projects/uswds-components/src/lib/sidenav/sidenav.component.spec.ts
@@ -1,0 +1,307 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { UsaSidenavModule } from './sidenav.module';
+import { SidenavModel } from './sidenav.model';
+import { UsaNavigationMode } from '../util/navigation';
+import { RouterModule } from '@angular/router';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLinks(count: number): SidenavModel[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `link-${i}`,
+    text: `Link ${i}`,
+    mode: UsaNavigationMode.EVENT,
+  }));
+}
+
+function makeLabelWithChildren(): SidenavModel[] {
+  return [
+    {
+      id: 'label-1',
+      text: 'Label 1',
+      mode: UsaNavigationMode.LABEL,
+      children: [
+        { id: 'child-1', text: 'Child 1', mode: UsaNavigationMode.EVENT },
+        { id: 'child-2', text: 'Child 2', mode: UsaNavigationMode.EVENT },
+      ],
+    },
+    {
+      id: 'label-2',
+      text: 'Label 2',
+      mode: UsaNavigationMode.LABEL,
+      children: [{ id: 'child-3', text: 'Child 3', mode: UsaNavigationMode.EVENT }],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Host component
+// ---------------------------------------------------------------------------
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-sidenav
+      [sidenavContent]="items"
+      [expandType]="expandType"
+      [autoCollapseLabels]="autoCollapseLabels"
+      [enableLabelCollapse]="enableLabelCollapse"
+      [selectFirstLabelChild]="selectFirstLabelChild"
+      (sidenavClicked)="onClicked($event)"
+    ></usa-sidenav>
+  `,
+})
+class HostComponent {
+  items: SidenavModel[] = makeLinks(3);
+  expandType: 'single' | 'multiple' | undefined = undefined;
+  autoCollapseLabels = true;
+  enableLabelCollapse = false;
+  selectFirstLabelChild = false;
+  lastClicked: SidenavModel | null = null;
+  onClicked(item: SidenavModel) {
+    this.lastClicked = item;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UsaSidenavComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [UsaSidenavModule, RouterModule.forRoot([])],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // --- Construction & rendering ---
+
+  it('should create the sidenav component', () => {
+    const el = fixture.debugElement.query(By.css('usa-sidenav'));
+    expect(el).toBeTruthy();
+  });
+
+  it('renders the correct number of top-level items', () => {
+    const items = fixture.debugElement.queryAll(By.css('ul.usa-sidenav > li.usa-sidenav__item'));
+    expect(items.length).toBe(3);
+  });
+
+  // --- Click & selection ---
+
+  it('emits sidenavClicked when an item is clicked', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const target = host.items[0];
+    sidenavComp.onSidenavItemClicked(target);
+    expect(host.lastClicked).toBe(target);
+  });
+
+  it('marks clicked item as selected', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const target = host.items[1];
+    sidenavComp.onSidenavItemClicked(target);
+    expect(target.selected).toBe(true);
+  });
+
+  it('deselects previously selected item on new click', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    sidenavComp.onSidenavItemClicked(host.items[0]);
+    sidenavComp.onSidenavItemClicked(host.items[1]);
+    expect(host.items[0].selected).toBe(false);
+    expect(host.items[1].selected).toBe(true);
+  });
+
+  // --- expandType: 'single' ---
+
+  it('collapses non-selected items when expandType is single', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'single';
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    sidenavComp.onSidenavItemClicked(host.items[0].children![0]);
+    fixture.detectChanges();
+
+    // label-2 (not in the selected path) should be collapsed
+    expect(host.items[1].collapsed).toBe(true);
+  });
+
+  it('expands selected branch when expandType is single', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'single';
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    sidenavComp.onSidenavItemClicked(host.items[0].children![0]);
+    fixture.detectChanges();
+
+    expect(host.items[0].collapsed).toBe(false);
+  });
+
+  // --- expandType: 'multiple' ---
+
+  it('leaves other branches expanded when expandType is multiple', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'multiple';
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    // expand first label manually
+    host.items[0].collapsed = false;
+    // click a child of label-2
+    sidenavComp.onSidenavItemClicked(host.items[1].children![0]);
+    fixture.detectChanges();
+
+    // label-1 should remain at whatever collapsed state it was in
+    expect(host.items[0].collapsed).toBe(false);
+  });
+
+  // --- enableLabelCollapse ---
+
+  it('does not collapse LABEL items when enableLabelCollapse is false', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'multiple';
+    host.enableLabelCollapse = false;
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const label = host.items[0];
+    const beforeCollapsed = label.collapsed;
+    sidenavComp.onSidenavItemClicked(label);
+    fixture.detectChanges();
+    // collapsed state should not have toggled
+    expect(label.collapsed).toBe(beforeCollapsed);
+  });
+
+  it('collapses LABEL items when enableLabelCollapse is true', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'multiple';
+    host.enableLabelCollapse = true;
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const label = host.items[0];
+    label.collapsed = false; // start expanded
+    sidenavComp.onSidenavItemClicked(label);
+    fixture.detectChanges();
+    expect(label.collapsed).toBe(true);
+  });
+
+  // --- expandAll / collapseAll ---
+
+  it('expandAll expands all children when expandType is multiple', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'multiple';
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    sidenavComp.expandAll();
+    host.items.forEach((item) => {
+      if (item.children) {
+        expect(item.collapsed).toBe(false);
+      }
+    });
+  });
+
+  it('expandAll does nothing when expandType is not multiple', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'single';
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    // single expand-type: collapsed was set true in ngOnInit
+    const collapsedBefore = host.items[0].collapsed;
+    sidenavComp.expandAll();
+    expect(host.items[0].collapsed).toBe(collapsedBefore);
+  });
+
+  it('collapseAll collapses all items', () => {
+    host.items = makeLabelWithChildren();
+    host.expandType = 'multiple';
+    fixture.detectChanges();
+
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    sidenavComp.expandAll();
+    sidenavComp.collapseAll();
+    host.items.forEach((item) => {
+      if (item.children) {
+        expect(item.collapsed).toBe(true);
+      }
+    });
+  });
+
+  // --- urlBuilder ---
+
+  it('urlBuilder returns the path when no queryParams', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const item: SidenavModel = { id: 'x', text: 'X', path: '/home' };
+    expect(sidenavComp.urlBuilder(item)).toBe('/home');
+  });
+
+  it('urlBuilder appends query params', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const item: SidenavModel = { id: 'x', text: 'X', path: '/search', queryParams: { q: 'hello', page: '1' } };
+    const url = sidenavComp.urlBuilder(item);
+    expect(url).toContain('/search?');
+    expect(url).toContain('q=hello');
+    expect(url).toContain('page=1');
+  });
+
+  it('urlBuilder appends params with & when path already has ?', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const item: SidenavModel = { id: 'x', text: 'X', path: '/search?existing=1', queryParams: { q: 'test' } };
+    const url = sidenavComp.urlBuilder(item);
+    expect(url).toContain('&q=test');
+  });
+
+  it('urlBuilder handles path ending with ? correctly', () => {
+    const sidenavComp = fixture.debugElement.query(By.css('usa-sidenav')).componentInstance;
+    const item: SidenavModel = { id: 'x', text: 'X', path: '/search?', queryParams: { q: 'test' } };
+    const url = sidenavComp.urlBuilder(item);
+    expect(url).toContain('/search?q=test');
+  });
+
+  // --- ngOnInit with expandType ---
+
+  it('sets collapsed=true on non-label items when expandType is provided', () => {
+    const items: SidenavModel[] = [
+      {
+        id: 'a',
+        text: 'A',
+        mode: UsaNavigationMode.EVENT,
+        children: [{ id: 'a1', text: 'A1', mode: UsaNavigationMode.EVENT }],
+      },
+    ];
+    // Re-create component so ngOnInit fires with these inputs
+    host.items = items;
+    host.expandType = 'single';
+    // Destroy and re-create the fixture to trigger ngOnInit fresh
+    const f2 = TestBed.createComponent(HostComponent);
+    f2.componentInstance.items = items;
+    f2.componentInstance.expandType = 'single';
+    f2.detectChanges();
+    expect(items[0].collapsed).toBe(true);
+  });
+
+  it('respects pre-set collapsed value on items', () => {
+    const items: SidenavModel[] = [{ id: 'a', text: 'A', mode: UsaNavigationMode.EVENT, collapsed: false }];
+    const f2 = TestBed.createComponent(HostComponent);
+    f2.componentInstance.items = items;
+    f2.componentInstance.expandType = 'single';
+    f2.detectChanges();
+    expect(items[0].collapsed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Adds unit test specs for four navigation/misc components that had no coverage: `breadcrumb`, `button-group`, `dropdown`, and `sidenav`.

**New files:**

- `projects/uswds-components/src/lib/breadcrumb/breadcrumb.component.spec.ts` (15 tests) — construction, nav show/hide (empty/null items, `hideSingleCrumb`), auto-selection of last item, `wrap` class, `selected` output, custom link template via `usaBreadcrumbLinkTemplate`, and `ngOnChanges` reaction to `items`/`hideSingleCrumb` changes.
- `projects/uswds-components/src/lib/button-group/button-group.component.spec.ts` (8 tests) — `<ul>` rendering, `isSegmented` class toggle on/off, `USWDSButtonGroupItem` host class, and content projection.
- `projects/uswds-components/src/lib/dropdown/dropdown.component.spec.ts` (14 tests) — `<select>` rendering, options list, disabled state, `optionChange` output, `ControlValueAccessor` (`writeValue`, `registerOnChange`, `registerOnTouched`), id/name attribute binding, and auto-generated id pattern.
- `projects/uswds-components/src/lib/sidenav/sidenav.component.spec.ts` (19 tests) — item rendering, click/selection/deselection, `expandType: 'single'` collapse behavior, `expandType: 'multiple'` independence, `enableLabelCollapse`, `expandAll`/`collapseAll`, `urlBuilder` (with/without query params, trailing `?`, `&` append), and `ngOnInit` collapse logic.

**Coverage after (vs. floor):**

| Metric | Before | After | Floor |
|---|---|---|---|
| Statements | ~81% | **90.16%** | 81% ✓ |
| Branches | ~83% | **91.52%** | 83% ✓ |
| Functions | ~48% | **71.27%** | 48% ✓ |
| Lines | ~81% | **90.16%** | 81% ✓ |

`coverage-floor.json` was **not** edited per the ratchet policy in #259.

## Motivation and Context

Closes #250

Part of the #237 coverage effort. Adds specs to four components in the navigation/misc group that had zero test coverage, bringing each to meaningful statement, branch, function, and line coverage.

## Type of Change (Select One and Apply Label)

- [ ] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [x] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [ ] Documentation / configuration update → Apply `documentation` label

## How to Test

1. `npm run test:components` — all 382 tests should pass.
2. `npm run coverage:check` — gate reads floors from `coverage-floor.json` and should report all four metrics passing.

**Expected result:** `✓ Coverage gate passed.` with stmt 90.16%, branch 91.52%, fn 71.27%, lines 90.16%.

## Screenshots (if appropriate)

N/A — test-only changes, no UI modifications.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [ ] `lint` passes (`npm run lint`) — no `lint` target configured in this workspace (see AGENTS.md)
- [ ] `build-prod` passes (`npm run build-prod`) — no source changes; test-only PR
- [x] Tests pass and coverage is reported (`npm run test:components` + `npm run coverage:check`)
- [ ] If this change requires a documentation update, I have updated it accordingly
- [ ] If there are dependent changes, they have been merged and published in downstream modules
