### PR TITLE
Add datepicker coverage specs to 88%

### DIFF
--- a/projects/uswds-components/src/lib/datepicker/calendar.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/calendar.spec.ts
@@ -1,0 +1,237 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { UsaDatePickerModule } from './date-picker.module';
+import { UsaCalendar } from './calendar/calendar';
+import { UsaCalendarView } from './calendar/calendar';
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-calendar
+      [startAt]="startAt"
+      [startView]="startView"
+      [selected]="selected"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      (selectedChange)="onSelectedChange($event)"
+      (yearSelected)="onYearSelected($event)"
+      (monthSelected)="onMonthSelected($event)"
+      (viewChanged)="onViewChanged($event)"
+    ></usa-calendar>
+  `,
+})
+class CalendarTestHostComponent {
+  startAt: Date | null = new Date(2024, 0, 15);
+  startView: UsaCalendarView = 'month';
+  selected: Date | null = null;
+  minDate: Date | null = null;
+  maxDate: Date | null = null;
+  selectedValues: (Date | null)[] = [];
+  yearSelectedValues: Date[] = [];
+  monthSelectedValues: Date[] = [];
+  viewChangedValues: UsaCalendarView[] = [];
+
+  onSelectedChange(d: Date | null) {
+    this.selectedValues.push(d);
+  }
+  onYearSelected(d: Date) {
+    this.yearSelectedValues.push(d);
+  }
+  onMonthSelected(d: Date) {
+    this.monthSelectedValues.push(d);
+  }
+  onViewChanged(v: UsaCalendarView) {
+    this.viewChangedValues.push(v);
+  }
+}
+
+describe('UsaCalendar', () => {
+  let fixture: ComponentFixture<CalendarTestHostComponent>;
+  let host: CalendarTestHostComponent;
+  let calendarDE: DebugElement;
+  let calendar: UsaCalendar<Date>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CalendarTestHostComponent],
+      imports: [UsaDatePickerModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarTestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    calendarDE = fixture.debugElement.query(By.directive(UsaCalendar));
+    calendar = calendarDE.componentInstance as UsaCalendar<Date>;
+  });
+
+  // -----------------------------------------------------------------------
+  // Construction & initial state
+  // -----------------------------------------------------------------------
+
+  describe('initial state', () => {
+    it('creates the component', () => {
+      expect(calendar).toBeTruthy();
+    });
+
+    it('starts in month view by default', () => {
+      expect(calendar.currentView).toBe('month');
+    });
+
+    it('sets activeDate from startAt input', () => {
+      expect(calendar.activeDate.getFullYear()).toBe(2024);
+      expect(calendar.activeDate.getMonth()).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // startView input — tested via freshly created fixtures
+  // -----------------------------------------------------------------------
+
+  describe('startView input', () => {
+    async function buildWithStartView(startView: UsaCalendarView) {
+      const f = TestBed.createComponent(CalendarTestHostComponent);
+      f.componentInstance.startView = startView;
+      f.detectChanges();
+      await f.whenStable();
+      return f.debugElement.query(By.directive(UsaCalendar)).componentInstance as UsaCalendar<Date>;
+    }
+
+    it('starts in year view when startView="year"', async () => {
+      const cal = await buildWithStartView('year');
+      expect(cal.currentView).toBe('year');
+    });
+
+    it('starts in multi-year view when startView="multi-year"', async () => {
+      const cal = await buildWithStartView('multi-year');
+      expect(cal.currentView).toBe('multi-year');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // View switching via public setters
+  // -----------------------------------------------------------------------
+
+  describe('currentView setter', () => {
+    it('switches to year view and emits viewChanged', () => {
+      // calendar starts in month; switching to year should emit
+      const before = host.viewChangedValues.length;
+      calendar.currentView = 'year';
+      fixture.detectChanges();
+      expect(calendar.currentView).toBe('year');
+      // viewChanged is internal to UsaCalendar — it uses its own EventEmitter,
+      // not the host binding.  Verify the view changed.
+      expect(calendar.currentView).toBe('year');
+    });
+
+    it('switches to multi-year view', () => {
+      calendar.currentView = 'multi-year';
+      fixture.detectChanges();
+      expect(calendar.currentView).toBe('multi-year');
+    });
+
+    it('does not emit viewChanged when setting the same view', () => {
+      const before = host.viewChangedValues.length;
+      calendar.currentView = 'month';
+      fixture.detectChanges();
+      // still month — no new emission
+      expect(host.viewChangedValues.length).toBe(before);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Date selection
+  // -----------------------------------------------------------------------
+
+  describe('date selection', () => {
+    it('emits selectedChange when _dateSelected is called with a new date', () => {
+      const d = new Date(2024, 0, 20);
+      calendar._dateSelected({ value: d, event: new MouseEvent('click') });
+      expect(host.selectedValues.length).toBe(1);
+    });
+
+    it('does not emit selectedChange when same date is selected again', () => {
+      const d = new Date(2024, 0, 20);
+      host.selected = d;
+      fixture.detectChanges();
+      calendar._dateSelected({ value: d, event: new MouseEvent('click') });
+      // sameDate match — no new emission
+      expect(host.selectedValues.length).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // min / max inputs
+  // -----------------------------------------------------------------------
+
+  describe('minDate / maxDate', () => {
+    it('accepts a minDate input', () => {
+      host.minDate = new Date(2024, 0, 1);
+      fixture.detectChanges();
+      expect(calendar.minDate).not.toBeNull();
+    });
+
+    it('accepts a maxDate input', () => {
+      host.maxDate = new Date(2024, 11, 31);
+      fixture.detectChanges();
+      expect(calendar.maxDate).not.toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Year / month relay outputs
+  // -----------------------------------------------------------------------
+
+  describe('year/month relay', () => {
+    it('relays year selected from multi-year view', () => {
+      const d = new Date(2025, 0, 1);
+      calendar._yearSelectedInMultiYearView(d);
+      expect(host.yearSelectedValues.length).toBe(1);
+    });
+
+    it('relays month selected from year view', () => {
+      const d = new Date(2024, 5, 1);
+      calendar._monthSelectedInYearView(d);
+      expect(host.monthSelectedValues.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ngOnChanges — re-initialises the view
+  // -----------------------------------------------------------------------
+
+  describe('ngOnChanges', () => {
+    it('emits stateChanges when minDate changes', () => {
+      let count = 0;
+      calendar.stateChanges.subscribe(() => count++);
+      host.minDate = new Date(2024, 0, 1);
+      fixture.detectChanges();
+      expect(count).toBeGreaterThan(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // updateTodaysDate
+  // -----------------------------------------------------------------------
+
+  describe('updateTodaysDate', () => {
+    it('can be called without error', () => {
+      expect(() => calendar.updateTodaysDate()).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _goToDateInView
+  // -----------------------------------------------------------------------
+
+  describe('_goToDateInView', () => {
+    it('changes activeDate and view', () => {
+      const d = new Date(2025, 5, 1);
+      calendar._goToDateInView(d, 'year');
+      fixture.detectChanges();
+      expect(calendar.currentView).toBe('year');
+      expect(calendar.activeDate.getFullYear()).toBe(2025);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/calendar.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/calendar.spec.ts
@@ -114,16 +114,16 @@ describe('UsaCalendar', () => {
   // -----------------------------------------------------------------------
 
   describe('currentView setter', () => {
-    it('switches to year view and emits viewChanged', () => {
-      // calendar starts in month; switching to year should emit
+    it('switches to year view and emits viewChanged', fakeAsync(() => {
+      // calendar starts in month; switching to year should emit viewChanged
       const before = host.viewChangedValues.length;
       calendar.currentView = 'year';
       fixture.detectChanges();
+      tick(); // flush async EventEmitter (created with `true`)
       expect(calendar.currentView).toBe('year');
-      // viewChanged is internal to UsaCalendar — it uses its own EventEmitter,
-      // not the host binding.  Verify the view changed.
-      expect(calendar.currentView).toBe('year');
-    });
+      expect(host.viewChangedValues.length).toBeGreaterThan(before);
+      expect(host.viewChangedValues[host.viewChangedValues.length - 1]).toBe('year');
+    }));
 
     it('switches to multi-year view', () => {
       calendar.currentView = 'multi-year';

--- a/projects/uswds-components/src/lib/datepicker/calendar/month-view.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/calendar/month-view.spec.ts
@@ -1,0 +1,259 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { UsaMonthView } from './month-view';
+import { UsaCalendarBody } from './calendar-body';
+import { KeyCode } from '../../util/key';
+import { DateAdapter } from '../dateadapter/date-adapter';
+import { NativeDateAdapter } from '../dateadapter/native-date-adapter';
+import { USA_DATE_FORMATS } from '../dateadapter/date-formats';
+import { USA_NATIVE_DATE_FORMATS } from '../dateadapter/native-date-formats';
+import { HoverClassModule } from '../../util/hover-class';
+import { USA_DATE_RANGE_SELECTION_STRATEGY, DefaultUsaCalendarRangeStrategy } from '../date-range-selection-strategy';
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-month-view
+      [activeDate]="activeDate"
+      [selected]="selected"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      [dateFilter]="dateFilter"
+      (selectedChange)="onSelected($event)"
+      (activeDateChange)="onActiveDateChange($event)"
+    ></usa-month-view>
+  `,
+})
+class MonthViewHostComponent {
+  activeDate: Date = new Date(2024, 0, 15); // Jan 15 2024
+  selected: Date | null = null;
+  minDate: Date | null = null;
+  maxDate: Date | null = null;
+  dateFilter: ((d: Date) => boolean) | undefined = undefined;
+
+  selectedValues: (Date | null)[] = [];
+  activeDateChanges: Date[] = [];
+
+  onSelected(d: Date | null) {
+    this.selectedValues.push(d);
+  }
+  onActiveDateChange(d: Date) {
+    this.activeDateChanges.push(d);
+  }
+}
+
+describe('UsaMonthView', () => {
+  let fixture: ComponentFixture<MonthViewHostComponent>;
+  let host: MonthViewHostComponent;
+  let monthView: UsaMonthView<Date>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MonthViewHostComponent, UsaMonthView, UsaCalendarBody],
+      imports: [CommonModule, HoverClassModule],
+      providers: [
+        { provide: DateAdapter, useClass: NativeDateAdapter },
+        { provide: USA_DATE_FORMATS, useValue: USA_NATIVE_DATE_FORMATS },
+        {
+          provide: USA_DATE_RANGE_SELECTION_STRATEGY,
+          useClass: DefaultUsaCalendarRangeStrategy,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MonthViewHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const de: DebugElement = fixture.debugElement.query(By.directive(UsaMonthView));
+    monthView = de.componentInstance as UsaMonthView<Date>;
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic render
+  // -----------------------------------------------------------------------
+
+  describe('rendering', () => {
+    it('creates the component', () => {
+      expect(monthView).toBeTruthy();
+    });
+
+    it('renders 7 weekday labels', () => {
+      expect(monthView._weekdays.length).toBe(7);
+    });
+
+    it('renders at least 4 weeks for January 2024', () => {
+      expect(monthView._weeks.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('sets _todayDate (may be null if today is not Jan 2024)', () => {
+      expect(monthView._todayDate !== undefined).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // activeDate input
+  // -----------------------------------------------------------------------
+
+  describe('activeDate input', () => {
+    it('re-renders when switching to a different month', () => {
+      host.activeDate = new Date(2024, 5, 1);
+      fixture.detectChanges();
+      expect(monthView._weekdays.length).toBe(7);
+    });
+
+    it('re-renders the month label when month changes', () => {
+      host.activeDate = new Date(2024, 5, 1); // June
+      fixture.detectChanges();
+      // Just verify weeks still populated
+      expect(monthView._weeks.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // selected input
+  // -----------------------------------------------------------------------
+
+  describe('selected input', () => {
+    it('accepts a date selection', () => {
+      host.selected = new Date(2024, 0, 10);
+      fixture.detectChanges();
+      expect(monthView.selected).not.toBeNull();
+    });
+
+    it('accepts null selection', () => {
+      host.selected = null;
+      fixture.detectChanges();
+      expect(monthView.selected).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // dateFilter
+  // -----------------------------------------------------------------------
+
+  describe('dateFilter', () => {
+    it('disables dates that fail the filter', () => {
+      // Set filter before first detectChanges; UsaMonthView reads it during _init()
+      host.dateFilter = (d: Date) => d.getDate() % 2 === 0;
+      // Re-create the fixture so the filter is present at init time
+      // (simpler: just directly call _init on the already-created view)
+      monthView.dateFilter = (d: Date) => d.getDate() % 2 === 0;
+      monthView._init();
+      fixture.detectChanges();
+      const oddDayCell = monthView._weeks.flat().find((c) => c.value % 2 !== 0);
+      expect(oddDayCell?.enabled).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard navigation
+  // -----------------------------------------------------------------------
+
+  describe('keyboard navigation', () => {
+    function dispatch(keyCode: number, options: Partial<KeyboardEventInit> = {}) {
+      const event = new KeyboardEvent('keydown', { keyCode, ...options });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      monthView._handleCalendarBodyKeydown(event);
+      fixture.detectChanges();
+    }
+
+    it('moves to next day on ArrowRight', () => {
+      const before = monthView.activeDate.getDate();
+      dispatch(KeyCode.ArrowRight);
+      expect(monthView.activeDate.getDate()).toBe(before + 1);
+    });
+
+    it('moves to previous day on ArrowLeft', () => {
+      const before = monthView.activeDate.getDate();
+      dispatch(KeyCode.ArrowLeft);
+      expect(monthView.activeDate.getDate()).toBe(before - 1);
+    });
+
+    it('moves up one week on ArrowUp', () => {
+      const before = monthView.activeDate.getDate();
+      dispatch(KeyCode.ArrowUp);
+      expect(monthView.activeDate.getDate()).toBe(before - 7);
+    });
+
+    it('moves down one week on ArrowDown', () => {
+      const before = monthView.activeDate.getDate();
+      dispatch(KeyCode.ArrowDown);
+      expect(monthView.activeDate.getDate()).toBe(before + 7);
+    });
+
+    it('moves to first day of month on Home', () => {
+      dispatch(KeyCode.Home);
+      expect(monthView.activeDate.getDate()).toBe(1);
+    });
+
+    it('moves to last day of month on End', () => {
+      dispatch(KeyCode.End);
+      expect(monthView.activeDate.getDate()).toBe(31);
+    });
+
+    it('moves to previous month on PageUp', () => {
+      const beforeMonth = monthView.activeDate.getMonth();
+      const beforeYear = monthView.activeDate.getFullYear();
+      dispatch(KeyCode.PageUp);
+      const newMonth = monthView.activeDate.getMonth();
+      const newYear = monthView.activeDate.getFullYear();
+      // month went backwards (either month decreased, or wrapped to December of previous year)
+      expect(newYear < beforeYear || (newYear === beforeYear && newMonth < beforeMonth)).toBe(true);
+    });
+
+    it('moves to next month on PageDown', () => {
+      const beforeMonth = monthView.activeDate.getMonth();
+      const beforeYear = monthView.activeDate.getFullYear();
+      dispatch(KeyCode.PageDown);
+      const newMonth = monthView.activeDate.getMonth();
+      const newYear = monthView.activeDate.getFullYear();
+      expect(newYear > beforeYear || (newYear === beforeYear && newMonth > beforeMonth)).toBe(true);
+    });
+
+    it('moves to previous year on alt+PageUp', () => {
+      const before = monthView.activeDate.getFullYear();
+      dispatch(KeyCode.PageUp, { altKey: true });
+      expect(monthView.activeDate.getFullYear()).toBe(before - 1);
+    });
+
+    it('moves to next year on alt+PageDown', () => {
+      const before = monthView.activeDate.getFullYear();
+      dispatch(KeyCode.PageDown, { altKey: true });
+      expect(monthView.activeDate.getFullYear()).toBe(before + 1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard selection (Space / Enter)
+  // -----------------------------------------------------------------------
+
+  describe('keyboard selection', () => {
+    function keydown(keyCode: number) {
+      const event = new KeyboardEvent('keydown', { keyCode });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      monthView._handleCalendarBodyKeydown(event);
+    }
+
+    function keyup(keyCode: number) {
+      const event = new KeyboardEvent('keyup', { keyCode });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      monthView._handleCalendarBodyKeyup(event);
+      fixture.detectChanges();
+    }
+
+    it('selects the active date when Space is pressed then released', () => {
+      keydown(KeyCode.Space);
+      keyup(KeyCode.Space);
+      expect(host.selectedValues.length).toBe(1);
+    });
+
+    it('selects the active date when Enter is pressed then released', () => {
+      keydown(KeyCode.Enter);
+      keyup(KeyCode.Enter);
+      expect(host.selectedValues.length).toBe(1);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/calendar/multi-year-view.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/calendar/multi-year-view.spec.ts
@@ -1,0 +1,279 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { UsaMultiYearView, yearsPerPage, yearsPerRow } from './multi-year-view';
+import { UsaCalendarBody } from './calendar-body';
+import { KeyCode } from '../../util/key';
+import { DateAdapter } from '../dateadapter/date-adapter';
+import { NativeDateAdapter } from '../dateadapter/native-date-adapter';
+import { HoverClassModule } from '../../util/hover-class';
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-multi-year-view
+      [activeDate]="activeDate"
+      [selected]="selected"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      (selectedChange)="onSelected($event)"
+      (yearSelected)="onYearSelected($event)"
+      (activeDateChange)="onActiveDateChange($event)"
+    ></usa-multi-year-view>
+  `,
+})
+class MultiYearViewHostComponent {
+  activeDate: Date = new Date(2024, 0, 1);
+  selected: Date | null = null;
+  minDate: Date | null = null;
+  maxDate: Date | null = null;
+
+  selectedValues: Date[] = [];
+  yearSelectedValues: Date[] = [];
+  activeDateChanges: Date[] = [];
+
+  onSelected(d: Date) {
+    this.selectedValues.push(d);
+  }
+  onYearSelected(d: Date) {
+    this.yearSelectedValues.push(d);
+  }
+  onActiveDateChange(d: Date) {
+    this.activeDateChanges.push(d);
+  }
+}
+
+describe('UsaMultiYearView', () => {
+  let fixture: ComponentFixture<MultiYearViewHostComponent>;
+  let host: MultiYearViewHostComponent;
+  let multiYearView: UsaMultiYearView<Date>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MultiYearViewHostComponent, UsaMultiYearView, UsaCalendarBody],
+      imports: [CommonModule, HoverClassModule],
+      providers: [{ provide: DateAdapter, useClass: NativeDateAdapter }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MultiYearViewHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const de: DebugElement = fixture.debugElement.query(By.directive(UsaMultiYearView));
+    multiYearView = de.componentInstance as UsaMultiYearView<Date>;
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic render
+  // -----------------------------------------------------------------------
+
+  describe('rendering', () => {
+    it('creates the component', () => {
+      expect(multiYearView).toBeTruthy();
+    });
+
+    it('renders the correct number of years', () => {
+      const totalYears = multiYearView._years.flat().length;
+      expect(totalYears).toBe(yearsPerPage);
+    });
+
+    it('sets _todayYear', () => {
+      expect(multiYearView._todayYear).toBe(new Date().getFullYear());
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // selected input
+  // -----------------------------------------------------------------------
+
+  describe('selected input', () => {
+    it('sets _selectedYear when a date is selected', () => {
+      host.selected = new Date(2024, 5, 1);
+      fixture.detectChanges();
+      expect(multiYearView._selectedYear).toBe(2024);
+    });
+
+    it('sets _selectedYear to null when selected is null', () => {
+      host.selected = null;
+      fixture.detectChanges();
+      expect(multiYearView._selectedYear).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // min / max
+  // -----------------------------------------------------------------------
+
+  describe('min / max constraints', () => {
+    it('disables years before minDate', () => {
+      multiYearView.minDate = new Date(2020, 0, 1);
+      multiYearView.activeDate = new Date(2020, 0, 1);
+      multiYearView._init();
+      fixture.detectChanges();
+      const years = multiYearView._years.flat();
+      const year2019 = years.find((c) => c.value === 2019);
+      if (year2019) {
+        expect(year2019.enabled).toBe(false);
+      }
+    });
+
+    it('disables years after maxDate', () => {
+      multiYearView.maxDate = new Date(2024, 11, 31);
+      multiYearView._init();
+      fixture.detectChanges();
+      const years = multiYearView._years.flat();
+      const futureYear = years.find((c) => c.value > 2024);
+      if (futureYear) {
+        expect(futureYear.enabled).toBe(false);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Year selection
+  // -----------------------------------------------------------------------
+
+  describe('year selection', () => {
+    it('emits selectedChange and yearSelected when _yearSelected is called', () => {
+      multiYearView._yearSelected({ value: 2025, event: new MouseEvent('click') });
+      fixture.detectChanges();
+      expect(host.selectedValues.length).toBe(1);
+      expect(host.yearSelectedValues.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getNextYears / getPreviousYears
+  // -----------------------------------------------------------------------
+
+  describe('getNextYears / getPreviousYears', () => {
+    it('getNextYears advances by yearsPerPage', () => {
+      const beforeYear = multiYearView.activeDate.getFullYear();
+      multiYearView.getNextYears();
+      fixture.detectChanges();
+      expect(multiYearView.activeDate.getFullYear()).toBe(beforeYear + yearsPerPage);
+    });
+
+    it('getPreviousYears retreats by yearsPerPage', () => {
+      const beforeYear = multiYearView.activeDate.getFullYear();
+      multiYearView.getPreviousYears();
+      fixture.detectChanges();
+      expect(multiYearView.activeDate.getFullYear()).toBe(beforeYear - yearsPerPage);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _getActiveCell
+  // -----------------------------------------------------------------------
+
+  describe('_getActiveCell', () => {
+    it('returns a number in [0, yearsPerPage)', () => {
+      const cell = multiYearView._getActiveCell();
+      expect(cell).toBeGreaterThanOrEqual(0);
+      expect(cell).toBeLessThan(yearsPerPage);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard navigation
+  // -----------------------------------------------------------------------
+
+  describe('keyboard navigation', () => {
+    function dispatch(keyCode: number, options: Partial<KeyboardEventInit> = {}) {
+      const event = new KeyboardEvent('keydown', { keyCode, ...options });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      multiYearView._handleCalendarBodyKeydown(event);
+      fixture.detectChanges();
+    }
+
+    it('moves back 1 year on ArrowLeft', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.ArrowLeft);
+      expect(multiYearView.activeDate.getFullYear()).toBe(before - 1);
+    });
+
+    it('moves forward 1 year on ArrowRight', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.ArrowRight);
+      expect(multiYearView.activeDate.getFullYear()).toBe(before + 1);
+    });
+
+    it('moves back yearsPerRow on ArrowUp', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.ArrowUp);
+      expect(multiYearView.activeDate.getFullYear()).toBe(before - yearsPerRow);
+    });
+
+    it('moves forward yearsPerRow on ArrowDown', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.ArrowDown);
+      expect(multiYearView.activeDate.getFullYear()).toBe(before + yearsPerRow);
+    });
+
+    it('moves to the first year in page on Home', () => {
+      dispatch(KeyCode.Home);
+      expect(multiYearView._getActiveCell()).toBe(0);
+    });
+
+    it('moves to the last year in page on End', () => {
+      dispatch(KeyCode.End);
+      expect(multiYearView._getActiveCell()).toBe(yearsPerPage - 1);
+    });
+
+    it('moves back yearsPerPage on PageUp', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.PageUp);
+      expect(multiYearView.activeDate.getFullYear()).toBe(before - yearsPerPage);
+    });
+
+    it('moves forward yearsPerPage on PageDown', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.PageDown);
+      expect(multiYearView.activeDate.getFullYear()).toBe(before + yearsPerPage);
+    });
+
+    it('moves back yearsPerPage*10 on alt+PageUp', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.PageUp, { altKey: true });
+      expect(multiYearView.activeDate.getFullYear()).toBe(before - yearsPerPage * 10);
+    });
+
+    it('moves forward yearsPerPage*10 on alt+PageDown', () => {
+      const before = multiYearView.activeDate.getFullYear();
+      dispatch(KeyCode.PageDown, { altKey: true });
+      expect(multiYearView.activeDate.getFullYear()).toBe(before + yearsPerPage * 10);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard selection
+  // -----------------------------------------------------------------------
+
+  describe('keyboard selection', () => {
+    function keydown(keyCode: number) {
+      const event = new KeyboardEvent('keydown', { keyCode });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      multiYearView._handleCalendarBodyKeydown(event);
+    }
+
+    function keyup(keyCode: number) {
+      const event = new KeyboardEvent('keyup', { keyCode });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      multiYearView._handleCalendarBodyKeyup(event);
+      fixture.detectChanges();
+    }
+
+    it('selects the active year on Space keydown+up', () => {
+      keydown(KeyCode.Space);
+      keyup(KeyCode.Space);
+      expect(host.selectedValues.length).toBe(1);
+    });
+
+    it('selects the active year on Enter keydown+up', () => {
+      keydown(KeyCode.Enter);
+      keyup(KeyCode.Enter);
+      expect(host.selectedValues.length).toBe(1);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/calendar/year-view.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/calendar/year-view.spec.ts
@@ -1,0 +1,240 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { UsaYearView } from './year-view';
+import { UsaCalendarBody } from './calendar-body';
+import { KeyCode } from '../../util/key';
+import { DateAdapter } from '../dateadapter/date-adapter';
+import { NativeDateAdapter } from '../dateadapter/native-date-adapter';
+import { USA_DATE_FORMATS } from '../dateadapter/date-formats';
+import { USA_NATIVE_DATE_FORMATS } from '../dateadapter/native-date-formats';
+import { HoverClassModule } from '../../util/hover-class';
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-year-view
+      [activeDate]="activeDate"
+      [selected]="selected"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      (selectedChange)="onSelected($event)"
+      (monthSelected)="onMonthSelected($event)"
+      (activeDateChange)="onActiveDateChange($event)"
+    ></usa-year-view>
+  `,
+})
+class YearViewHostComponent {
+  activeDate: Date = new Date(2024, 6, 15); // July 2024 — avoids edge wrapping issues
+  selected: Date | null = null;
+  minDate: Date | null = null;
+  maxDate: Date | null = null;
+
+  selectedValues: Date[] = [];
+  monthSelectedValues: Date[] = [];
+  activeDateChanges: Date[] = [];
+
+  onSelected(d: Date) {
+    this.selectedValues.push(d);
+  }
+  onMonthSelected(d: Date) {
+    this.monthSelectedValues.push(d);
+  }
+  onActiveDateChange(d: Date) {
+    this.activeDateChanges.push(d);
+  }
+}
+
+describe('UsaYearView', () => {
+  let fixture: ComponentFixture<YearViewHostComponent>;
+  let host: YearViewHostComponent;
+  let yearView: UsaYearView<Date>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [YearViewHostComponent, UsaYearView, UsaCalendarBody],
+      imports: [CommonModule, HoverClassModule],
+      providers: [
+        { provide: DateAdapter, useClass: NativeDateAdapter },
+        { provide: USA_DATE_FORMATS, useValue: USA_NATIVE_DATE_FORMATS },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(YearViewHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const de: DebugElement = fixture.debugElement.query(By.directive(UsaYearView));
+    yearView = de.componentInstance as UsaYearView<Date>;
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic render
+  // -----------------------------------------------------------------------
+
+  describe('rendering', () => {
+    it('creates the component', () => {
+      expect(yearView).toBeTruthy();
+    });
+
+    it('renders a 3×4 grid of months', () => {
+      expect(yearView._months.length).toBe(3);
+      expect(yearView._months[0].length).toBe(4);
+    });
+
+    it('sets _yearLabel', () => {
+      expect(yearView._yearLabel).toContain('2024');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // selected input
+  // -----------------------------------------------------------------------
+
+  describe('selected input', () => {
+    it('sets _selectedMonth when selected is in same year', () => {
+      host.selected = new Date(2024, 5, 1);
+      fixture.detectChanges();
+      expect(yearView._selectedMonth).toBe(5);
+    });
+
+    it('sets _selectedMonth to null when selected is in a different year', () => {
+      host.selected = new Date(2025, 5, 1);
+      fixture.detectChanges();
+      expect(yearView._selectedMonth).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // min / max
+  // -----------------------------------------------------------------------
+
+  describe('min / max constraints', () => {
+    it('disables months before minDate', () => {
+      yearView.minDate = new Date(2024, 5, 1); // June min
+      yearView._init();
+      fixture.detectChanges();
+      expect(yearView._months[0][0].enabled).toBe(false); // January disabled
+    });
+
+    it('disables months after maxDate', () => {
+      yearView.maxDate = new Date(2024, 5, 1); // June max
+      yearView._init();
+      fixture.detectChanges();
+      expect(yearView._months[2][3].enabled).toBe(false); // December disabled
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Month selection
+  // -----------------------------------------------------------------------
+
+  describe('month selection', () => {
+    it('emits selectedChange and monthSelected when _monthSelected is called', () => {
+      yearView._monthSelected({ value: 5, event: new MouseEvent('click') });
+      fixture.detectChanges();
+      expect(host.selectedValues.length).toBe(1);
+      expect(host.monthSelectedValues.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard navigation
+  // -----------------------------------------------------------------------
+
+  describe('keyboard navigation', () => {
+    function dispatch(keyCode: number, options: Partial<KeyboardEventInit> = {}) {
+      const event = new KeyboardEvent('keydown', { keyCode, ...options });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      yearView._handleCalendarBodyKeydown(event);
+      fixture.detectChanges();
+    }
+
+    it('moves back 1 month on ArrowLeft', () => {
+      const before = yearView.activeDate.getMonth();
+      dispatch(KeyCode.ArrowLeft);
+      // July(6) → June(5)
+      expect(yearView.activeDate.getMonth()).toBe(before - 1);
+    });
+
+    it('moves forward 1 month on ArrowRight', () => {
+      const before = yearView.activeDate.getMonth();
+      dispatch(KeyCode.ArrowRight);
+      expect(yearView.activeDate.getMonth()).toBe(before + 1);
+    });
+
+    it('moves back 4 months on ArrowUp', () => {
+      const before = yearView.activeDate.getMonth(); // 6 → 2
+      dispatch(KeyCode.ArrowUp);
+      expect(yearView.activeDate.getMonth()).toBe(before - 4);
+    });
+
+    it('moves forward 4 months on ArrowDown', () => {
+      const before = yearView.activeDate.getMonth(); // 6 → 10
+      dispatch(KeyCode.ArrowDown);
+      expect(yearView.activeDate.getMonth()).toBe(before + 4);
+    });
+
+    it('moves to January on Home', () => {
+      dispatch(KeyCode.Home);
+      expect(yearView.activeDate.getMonth()).toBe(0);
+    });
+
+    it('moves to December on End', () => {
+      dispatch(KeyCode.End);
+      expect(yearView.activeDate.getMonth()).toBe(11);
+    });
+
+    it('moves back 1 year on PageUp', () => {
+      dispatch(KeyCode.PageUp);
+      expect(yearView.activeDate.getFullYear()).toBe(2023);
+    });
+
+    it('moves forward 1 year on PageDown', () => {
+      dispatch(KeyCode.PageDown);
+      expect(yearView.activeDate.getFullYear()).toBe(2025);
+    });
+
+    it('moves back 10 years on alt+PageUp', () => {
+      dispatch(KeyCode.PageUp, { altKey: true });
+      expect(yearView.activeDate.getFullYear()).toBe(2014);
+    });
+
+    it('moves forward 10 years on alt+PageDown', () => {
+      dispatch(KeyCode.PageDown, { altKey: true });
+      expect(yearView.activeDate.getFullYear()).toBe(2034);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard selection
+  // -----------------------------------------------------------------------
+
+  describe('keyboard selection', () => {
+    function keydown(keyCode: number) {
+      const event = new KeyboardEvent('keydown', { keyCode });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      yearView._handleCalendarBodyKeydown(event);
+    }
+
+    function keyup(keyCode: number) {
+      const event = new KeyboardEvent('keyup', { keyCode });
+      Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+      yearView._handleCalendarBodyKeyup(event);
+      fixture.detectChanges();
+    }
+
+    it('selects the active month on Space keydown+up', () => {
+      keydown(KeyCode.Space);
+      keyup(KeyCode.Space);
+      expect(host.selectedValues.length).toBe(1);
+    });
+
+    it('selects the active month on Enter keydown+up', () => {
+      keydown(KeyCode.Enter);
+      keyup(KeyCode.Enter);
+      expect(host.selectedValues.length).toBe(1);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/date-picker-button.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-picker-button.spec.ts
@@ -1,0 +1,94 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { UsaDatePickerModule } from './date-picker.module';
+import { UsaDatePickerButton } from './date-picker-button';
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-date-picker-wrapper>
+      <input usaDatePicker />
+      <usa-date-picker #picker></usa-date-picker>
+      <usa-date-picker-button [for]="picker" [disabled]="buttonDisabled"></usa-date-picker-button>
+    </usa-date-picker-wrapper>
+  `,
+})
+class DatePickerButtonHostComponent {
+  buttonDisabled = false;
+}
+
+describe('UsaDatePickerButton', () => {
+  let fixture: ComponentFixture<DatePickerButtonHostComponent>;
+  let host: DatePickerButtonHostComponent;
+  let buttonDE: DebugElement;
+  let button: UsaDatePickerButton<Date>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DatePickerButtonHostComponent],
+      imports: [UsaDatePickerModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatePickerButtonHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    buttonDE = fixture.debugElement.query(By.directive(UsaDatePickerButton));
+    button = buttonDE.componentInstance as UsaDatePickerButton<Date>;
+  });
+
+  // -----------------------------------------------------------------------
+  // Construction
+  // -----------------------------------------------------------------------
+
+  describe('construction', () => {
+    it('creates the component', () => {
+      expect(button).toBeTruthy();
+    });
+
+    it('has the usa-date-picker__button class', () => {
+      expect((buttonDE.nativeElement as HTMLElement).classList).toContain('usa-date-picker__button');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // disabled property
+  // -----------------------------------------------------------------------
+
+  describe('disabled', () => {
+    it('inherits disabled state from the linked datePicker', () => {
+      // By default the picker and input are not disabled
+      expect(button.disabled).toBe(false);
+    });
+
+    it('can be explicitly disabled via input', () => {
+      host.buttonDisabled = true;
+      fixture.detectChanges();
+      expect(button.disabled).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _toggle
+  // -----------------------------------------------------------------------
+
+  describe('_toggle', () => {
+    it('does nothing when datePicker is null', () => {
+      const originalPicker = button.datePicker;
+      (button as any).datePicker = null;
+      expect(() => button._toggle(new MouseEvent('click'))).not.toThrow();
+      (button as any).datePicker = originalPicker;
+    });
+
+    it('does not open when disabled', () => {
+      host.buttonDisabled = true;
+      fixture.detectChanges();
+      const picker = button.datePicker;
+      const opened = picker.opened;
+      button._toggle(new MouseEvent('click'));
+      fixture.detectChanges();
+      expect(picker.opened).toBe(opened);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/date-picker-errors.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-picker-errors.spec.ts
@@ -1,0 +1,17 @@
+import { createMissingDateImplError } from './date-picker-errors';
+
+describe('createMissingDateImplError', () => {
+  it('returns an Error instance', () => {
+    expect(createMissingDateImplError('DateAdapter')).toBeInstanceOf(Error);
+  });
+
+  it('message contains the provider name', () => {
+    const err = createMissingDateImplError('MyProvider');
+    expect(err.message).toContain('MyProvider');
+  });
+
+  it('message mentions UsaDatePicker', () => {
+    const err = createMissingDateImplError('DateAdapter');
+    expect(err.message).toContain('UsaDatePicker');
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/date-picker-input.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-picker-input.spec.ts
@@ -1,0 +1,210 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ReactiveFormsModule, FormControl, Validators } from '@angular/forms';
+import { UsaDatePickerModule } from './date-picker.module';
+import { UsaDatePickerInput } from './date-picker-input';
+import { KeyCode } from '../util/key';
+
+@Component({
+  standalone: false,
+  template: `
+    <usa-date-picker-wrapper>
+      <input
+        #input
+        usaDatePicker
+        [min]="min"
+        [max]="max"
+        [usaDatePickerFilter]="dateFilter"
+        (dateChange)="onDateChange($event)"
+        (dateInput)="onDateInput($event)"
+      />
+      <usa-date-picker #picker></usa-date-picker>
+      <usa-date-picker-button [for]="picker"></usa-date-picker-button>
+    </usa-date-picker-wrapper>
+  `,
+})
+class DatePickerInputHostComponent {
+  min: Date | null = null;
+  max: Date | null = null;
+  dateFilter: ((d: Date | null) => boolean) | null = null;
+
+  dateChanges: any[] = [];
+  dateInputs: any[] = [];
+
+  onDateChange(e: any) {
+    this.dateChanges.push(e);
+  }
+  onDateInput(e: any) {
+    this.dateInputs.push(e);
+  }
+}
+
+describe('UsaDatePickerInput', () => {
+  let fixture: ComponentFixture<DatePickerInputHostComponent>;
+  let host: DatePickerInputHostComponent;
+  let inputDE: DebugElement;
+  let datePickerInput: UsaDatePickerInput<Date>;
+  let nativeInput: HTMLInputElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DatePickerInputHostComponent],
+      imports: [UsaDatePickerModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatePickerInputHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    inputDE = fixture.debugElement.query(By.directive(UsaDatePickerInput));
+    datePickerInput = inputDE.injector.get(UsaDatePickerInput) as UsaDatePickerInput<Date>;
+    nativeInput = inputDE.nativeElement as HTMLInputElement;
+  });
+
+  // -----------------------------------------------------------------------
+  // Construction
+  // -----------------------------------------------------------------------
+
+  describe('construction', () => {
+    it('creates the directive', () => {
+      expect(datePickerInput).toBeTruthy();
+    });
+
+    it('has usa-input CSS class', () => {
+      expect(nativeInput.classList).toContain('usa-input');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // value input / output
+  // -----------------------------------------------------------------------
+
+  describe('value', () => {
+    it('is null or undefined initially (no model registered yet)', () => {
+      // Value is undefined when no model is registered yet; null after writeValue(null)
+      expect(datePickerInput.value == null).toBe(true);
+    });
+
+    it('can be set programmatically via writeValue', () => {
+      datePickerInput.writeValue(new Date(2024, 0, 15));
+      expect(datePickerInput.value).not.toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // min / max validation
+  // -----------------------------------------------------------------------
+
+  describe('min / max', () => {
+    it('getStartValue returns current value (null or undefined initially)', () => {
+      expect(datePickerInput.getStartValue() == null).toBe(true);
+    });
+
+    it('getConnectedOverlayOrigin returns an ElementRef', () => {
+      expect(datePickerInput.getConnectedOverlayOrigin()).toBeTruthy();
+    });
+
+    it('getOverlayLabelId returns null when no aria-labelledby', () => {
+      expect(datePickerInput.getOverlayLabelId()).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard: Alt+ArrowDown opens the picker
+  // -----------------------------------------------------------------------
+
+  describe('keyboard', () => {
+    it('Alt+ArrowDown triggers _openPopup (calls datePicker.open)', () => {
+      const picker = (datePickerInput as any)._datePicker;
+      if (!picker) return; // picker not registered yet
+      let opened = false;
+      vi.spyOn(picker, 'open').mockImplementation(() => {
+        opened = true;
+      });
+
+      const event = new KeyboardEvent('keydown', { keyCode: KeyCode.ArrowDown, altKey: true });
+      Object.defineProperty(event, 'keyCode', { get: () => KeyCode.ArrowDown });
+      datePickerInput._onKeydown(event);
+      expect(opened).toBe(true);
+    });
+
+    it('does not open on other keys', () => {
+      const picker = (datePickerInput as any)._datePicker;
+      if (!picker) return;
+      let opened = false;
+      vi.spyOn(picker, 'open').mockImplementation(() => {
+        opened = true;
+      });
+
+      const event = new KeyboardEvent('keydown', { keyCode: KeyCode.ArrowDown });
+      Object.defineProperty(event, 'keyCode', { get: () => KeyCode.ArrowDown });
+      datePickerInput._onKeydown(event);
+      expect(opened).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // disabled state
+  // -----------------------------------------------------------------------
+
+  describe('disabled', () => {
+    it('starts enabled', () => {
+      expect(datePickerInput.disabled).toBe(false);
+    });
+
+    it('can be set via setDisabledState', () => {
+      datePickerInput.setDisabledState(true);
+      expect(datePickerInput.disabled).toBe(true);
+      datePickerInput.setDisabledState(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // CVA registration
+  // -----------------------------------------------------------------------
+
+  describe('ControlValueAccessor', () => {
+    it('registerOnChange accepts a function', () => {
+      expect(() => datePickerInput.registerOnChange(() => {})).not.toThrow();
+    });
+
+    it('registerOnTouched accepts a function', () => {
+      expect(() => datePickerInput.registerOnTouched(() => {})).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _onInput / _onChange / _onBlur
+  // -----------------------------------------------------------------------
+
+  describe('input events', () => {
+    it('_onInput with empty string does not throw', () => {
+      expect(() => datePickerInput._onInput('')).not.toThrow();
+    });
+
+    it('_onChange emits a dateChange event', () => {
+      const before = host.dateChanges.length;
+      datePickerInput._onChange();
+      expect(host.dateChanges.length).toBeGreaterThan(before);
+    });
+
+    it('_onBlur does not throw', () => {
+      expect(() => datePickerInput._onBlur()).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // stateChanges
+  // -----------------------------------------------------------------------
+
+  describe('stateChanges', () => {
+    it('emits when disabled changes', () => {
+      let emitted = false;
+      datePickerInput.stateChanges.subscribe(() => (emitted = true));
+      datePickerInput.disabled = true;
+      expect(emitted).toBe(true);
+      datePickerInput.setDisabledState(false);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/date-picker-input.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-picker-input.spec.ts
@@ -1,7 +1,7 @@
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ReactiveFormsModule, FormControl, Validators } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 import { UsaDatePickerModule } from './date-picker.module';
 import { UsaDatePickerInput } from './date-picker-input';
 import { KeyCode } from '../util/key';
@@ -12,7 +12,7 @@ import { KeyCode } from '../util/key';
     <usa-date-picker-wrapper>
       <input
         #input
-        usaDatePicker
+        [usaDatePicker]="picker"
         [min]="min"
         [max]="max"
         [usaDatePickerFilter]="dateFilter"
@@ -117,7 +117,7 @@ describe('UsaDatePickerInput', () => {
   describe('keyboard', () => {
     it('Alt+ArrowDown triggers _openPopup (calls datePicker.open)', () => {
       const picker = (datePickerInput as any)._datePicker;
-      if (!picker) return; // picker not registered yet
+      expect(picker).toBeTruthy(); // fails fast if input registration broke
       let opened = false;
       vi.spyOn(picker, 'open').mockImplementation(() => {
         opened = true;
@@ -131,7 +131,7 @@ describe('UsaDatePickerInput', () => {
 
     it('does not open on other keys', () => {
       const picker = (datePickerInput as any)._datePicker;
-      if (!picker) return;
+      expect(picker).toBeTruthy();
       let opened = false;
       vi.spyOn(picker, 'open').mockImplementation(() => {
         opened = true;

--- a/projects/uswds-components/src/lib/datepicker/date-range-selection-strategy.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-range-selection-strategy.spec.ts
@@ -1,0 +1,105 @@
+import { NativeDateAdapter } from './dateadapter/native-date-adapter';
+import {
+  DefaultUsaCalendarRangeStrategy,
+  USA_CALENDAR_RANGE_STRATEGY_PROVIDER_FACTORY,
+} from './date-range-selection-strategy';
+import { DateRange } from './date-selection-model';
+
+function makeAdapter(): NativeDateAdapter {
+  return new NativeDateAdapter('en-US');
+}
+
+describe('DefaultUsaCalendarRangeStrategy', () => {
+  let adapter: NativeDateAdapter;
+  let strategy: DefaultUsaCalendarRangeStrategy<Date>;
+
+  beforeEach(() => {
+    adapter = makeAdapter();
+    strategy = new DefaultUsaCalendarRangeStrategy(adapter);
+  });
+
+  // -----------------------------------------------------------------------
+  // selectionFinished
+  // -----------------------------------------------------------------------
+
+  describe('selectionFinished', () => {
+    it('sets start when both start and end are null', () => {
+      const d = new Date(2024, 0, 10);
+      const range = strategy.selectionFinished(d, new DateRange<Date>(null, null));
+      expect(adapter.sameDate(range.start, d)).toBe(true);
+      expect(range.end).toBeNull();
+    });
+
+    it('sets end when start is set and date >= start', () => {
+      const start = new Date(2024, 0, 1);
+      const end = new Date(2024, 0, 15);
+      const range = strategy.selectionFinished(end, new DateRange(start, null));
+      expect(adapter.sameDate(range.start, start)).toBe(true);
+      expect(adapter.sameDate(range.end!, end)).toBe(true);
+    });
+
+    it('resets to new start when date < start (end would be before start)', () => {
+      const start = new Date(2024, 0, 15);
+      const earlier = new Date(2024, 0, 5);
+      const range = strategy.selectionFinished(earlier, new DateRange(start, null));
+      expect(adapter.sameDate(range.start, earlier)).toBe(true);
+      expect(range.end).toBeNull();
+    });
+
+    it('resets when both start and end are already set', () => {
+      const newDate = new Date(2024, 5, 1);
+      const range = strategy.selectionFinished(newDate, new DateRange(new Date(2024, 0, 1), new Date(2024, 0, 31)));
+      expect(adapter.sameDate(range.start, newDate)).toBe(true);
+      expect(range.end).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // createPreview
+  // -----------------------------------------------------------------------
+
+  describe('createPreview', () => {
+    it('returns empty range when currentRange has no start', () => {
+      const preview = strategy.createPreview(new Date(2024, 0, 15), new DateRange<Date>(null, null));
+      expect(preview.start).toBeNull();
+      expect(preview.end).toBeNull();
+    });
+
+    it('returns empty range when currentRange already has an end', () => {
+      const preview = strategy.createPreview(
+        new Date(2024, 0, 20),
+        new DateRange(new Date(2024, 0, 1), new Date(2024, 0, 10)),
+      );
+      expect(preview.start).toBeNull();
+      expect(preview.end).toBeNull();
+    });
+
+    it('returns preview range from start to activeDate when start is set and end is null', () => {
+      const start = new Date(2024, 0, 1);
+      const active = new Date(2024, 0, 15);
+      const preview = strategy.createPreview(active, new DateRange(start, null));
+      expect(adapter.sameDate(preview.start, start)).toBe(true);
+      expect(adapter.sameDate(preview.end!, active)).toBe(true);
+    });
+
+    it('returns empty range when activeDate is null', () => {
+      const preview = strategy.createPreview(null, new DateRange(new Date(2024, 0, 1), null));
+      expect(preview.start).toBeNull();
+      expect(preview.end).toBeNull();
+    });
+  });
+});
+
+describe('USA_CALENDAR_RANGE_STRATEGY_PROVIDER_FACTORY', () => {
+  it('returns the parent when truthy', () => {
+    const adapter = makeAdapter();
+    const parent = new DefaultUsaCalendarRangeStrategy(adapter);
+    expect(USA_CALENDAR_RANGE_STRATEGY_PROVIDER_FACTORY(parent, adapter)).toBe(parent);
+  });
+
+  it('creates a new strategy when parent is falsy', () => {
+    const adapter = makeAdapter();
+    const result = USA_CALENDAR_RANGE_STRATEGY_PROVIDER_FACTORY(null as any, adapter);
+    expect(result).toBeInstanceOf(DefaultUsaCalendarRangeStrategy);
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/date-selection-model.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-selection-model.spec.ts
@@ -1,0 +1,256 @@
+import { TestBed } from '@angular/core/testing';
+import { DateAdapter } from './dateadapter/date-adapter';
+import { NativeDateAdapter } from './dateadapter/native-date-adapter';
+import {
+  DateRange,
+  UsaSingleDateSelectionModel,
+  UsaRangeDateSelectionModel,
+  UsaDateSelectionModel,
+  USA_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
+  USA_RANGE_DATE_SELECTION_MODEL_PROVIDER,
+  USA_SINGLE_DATE_SELECTION_MODEL_FACTORY,
+  USA_RANGE_DATE_SELECTION_MODEL_FACTORY,
+} from './date-selection-model';
+
+function makeAdapter(): NativeDateAdapter {
+  return new NativeDateAdapter('en-US');
+}
+
+describe('DateRange', () => {
+  it('stores start and end', () => {
+    const start = new Date(2024, 0, 1);
+    const end = new Date(2024, 0, 31);
+    const range = new DateRange(start, end);
+    expect(range.start).toBe(start);
+    expect(range.end).toBe(end);
+  });
+
+  it('allows null start and end', () => {
+    const range = new DateRange<Date>(null, null);
+    expect(range.start).toBeNull();
+    expect(range.end).toBeNull();
+  });
+});
+
+describe('UsaSingleDateSelectionModel', () => {
+  let adapter: NativeDateAdapter;
+  let model: UsaSingleDateSelectionModel<Date>;
+
+  beforeEach(() => {
+    adapter = makeAdapter();
+    model = new UsaSingleDateSelectionModel<Date>(adapter);
+  });
+
+  it('starts with null selection', () => {
+    expect(model.selection).toBeNull();
+  });
+
+  describe('add', () => {
+    it('sets the selection to the given date', () => {
+      const d = new Date(2024, 0, 15);
+      model.add(d);
+      expect(model.selection).toBe(d);
+    });
+
+    it('replaces a previous selection', () => {
+      model.add(new Date(2024, 0, 1));
+      const d2 = new Date(2024, 5, 15);
+      model.add(d2);
+      expect(model.selection).toBe(d2);
+    });
+
+    it('accepts null to clear selection', () => {
+      model.add(new Date(2024, 0, 1));
+      model.add(null);
+      expect(model.selection).toBeNull();
+    });
+  });
+
+  describe('isValid', () => {
+    it('returns false when selection is null', () => {
+      expect(model.isValid()).toBe(false);
+    });
+
+    it('returns true when selection is a valid date', () => {
+      model.add(new Date(2024, 0, 15));
+      expect(model.isValid()).toBe(true);
+    });
+
+    it('returns false for an invalid date', () => {
+      model.add(new Date(NaN));
+      expect(model.isValid()).toBe(false);
+    });
+  });
+
+  describe('isComplete', () => {
+    it('returns false when selection is null', () => {
+      expect(model.isComplete()).toBe(false);
+    });
+
+    it('returns true when a date is set', () => {
+      model.add(new Date(2024, 0, 15));
+      expect(model.isComplete()).toBe(true);
+    });
+  });
+
+  describe('clone', () => {
+    it('returns a new model with the same selection', () => {
+      const d = new Date(2024, 0, 15);
+      model.add(d);
+      const clone = model.clone();
+      expect(clone).not.toBe(model);
+      expect(adapter.sameDate(clone.selection, d)).toBe(true);
+    });
+  });
+
+  describe('updateSelection / selectionChanged', () => {
+    it('emits on selectionChanged when updated', () => {
+      let emitted = false;
+      model.selectionChanged.subscribe(() => (emitted = true));
+      model.updateSelection(new Date(2024, 0, 15), {});
+      expect(emitted).toBe(true);
+    });
+
+    it('emits the new selection and source', () => {
+      const d = new Date(2024, 0, 15);
+      const source = {};
+      let change: any;
+      model.selectionChanged.subscribe((c) => (change = c));
+      model.updateSelection(d, source);
+      expect(adapter.sameDate(change.selection, d)).toBe(true);
+      expect(change.source).toBe(source);
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('completes the selectionChanged subject', () => {
+      let completed = false;
+      model.selectionChanged.subscribe({ complete: () => (completed = true) });
+      model.ngOnDestroy();
+      expect(completed).toBe(true);
+    });
+  });
+});
+
+describe('UsaRangeDateSelectionModel', () => {
+  let adapter: NativeDateAdapter;
+  let model: UsaRangeDateSelectionModel<Date>;
+
+  beforeEach(() => {
+    adapter = makeAdapter();
+    model = new UsaRangeDateSelectionModel<Date>(adapter);
+  });
+
+  it('starts with an empty range', () => {
+    expect(model.selection.start).toBeNull();
+    expect(model.selection.end).toBeNull();
+  });
+
+  describe('add', () => {
+    it('sets start when both are null', () => {
+      const d = new Date(2024, 0, 1);
+      model.add(d);
+      expect(adapter.sameDate(model.selection.start, d)).toBe(true);
+      expect(model.selection.end).toBeNull();
+    });
+
+    it('sets end when start is set and end is null', () => {
+      const start = new Date(2024, 0, 1);
+      const end = new Date(2024, 0, 15);
+      model.add(start);
+      model.add(end);
+      expect(adapter.sameDate(model.selection.end, end)).toBe(true);
+    });
+
+    it('resets to new start when both are already set', () => {
+      model.add(new Date(2024, 0, 1));
+      model.add(new Date(2024, 0, 15));
+      const newStart = new Date(2024, 5, 1);
+      model.add(newStart);
+      expect(adapter.sameDate(model.selection.start, newStart)).toBe(true);
+      expect(model.selection.end).toBeNull();
+    });
+  });
+
+  describe('isValid', () => {
+    it('returns true for an empty range', () => {
+      expect(model.isValid()).toBe(true);
+    });
+
+    it('returns true for a complete valid range', () => {
+      model.add(new Date(2024, 0, 1));
+      model.add(new Date(2024, 0, 15));
+      expect(model.isValid()).toBe(true);
+    });
+
+    it('returns false when start is after end', () => {
+      model.updateSelection(new DateRange(new Date(2024, 0, 15), new Date(2024, 0, 1)), {});
+      expect(model.isValid()).toBe(false);
+    });
+
+    it('returns true for a partial range with valid start', () => {
+      model.add(new Date(2024, 0, 1));
+      expect(model.isValid()).toBe(true);
+    });
+  });
+
+  describe('isComplete', () => {
+    it('returns false when range is empty', () => {
+      expect(model.isComplete()).toBe(false);
+    });
+
+    it('returns false when only start is set', () => {
+      model.add(new Date(2024, 0, 1));
+      expect(model.isComplete()).toBe(false);
+    });
+
+    it('returns true when both start and end are set', () => {
+      model.add(new Date(2024, 0, 1));
+      model.add(new Date(2024, 0, 15));
+      expect(model.isComplete()).toBe(true);
+    });
+  });
+
+  describe('clone', () => {
+    it('returns a new model with the same range', () => {
+      const start = new Date(2024, 0, 1);
+      const end = new Date(2024, 0, 15);
+      model.add(start);
+      model.add(end);
+      const clone = model.clone();
+      expect(clone).not.toBe(model);
+      expect(adapter.sameDate(clone.selection.start, start)).toBe(true);
+      expect(adapter.sameDate(clone.selection.end, end)).toBe(true);
+    });
+  });
+});
+
+describe('USA_SINGLE_DATE_SELECTION_MODEL_FACTORY', () => {
+  it('returns the parent when parent is truthy', () => {
+    const adapter = makeAdapter();
+    const parent = new UsaSingleDateSelectionModel(adapter);
+    const result = USA_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent, adapter);
+    expect(result).toBe(parent);
+  });
+
+  it('creates a new model when parent is falsy', () => {
+    const adapter = makeAdapter();
+    const result = USA_SINGLE_DATE_SELECTION_MODEL_FACTORY(null as any, adapter);
+    expect(result).toBeInstanceOf(UsaSingleDateSelectionModel);
+  });
+});
+
+describe('USA_RANGE_DATE_SELECTION_MODEL_FACTORY', () => {
+  it('returns the parent when parent is truthy', () => {
+    const adapter = makeAdapter();
+    const parent = new UsaSingleDateSelectionModel(adapter);
+    const result = USA_RANGE_DATE_SELECTION_MODEL_FACTORY(parent, adapter);
+    expect(result).toBe(parent);
+  });
+
+  it('creates a new range model when parent is falsy', () => {
+    const adapter = makeAdapter();
+    const result = USA_RANGE_DATE_SELECTION_MODEL_FACTORY(null as any, adapter);
+    expect(result).toBeInstanceOf(UsaRangeDateSelectionModel);
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/date-selection-model.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/date-selection-model.spec.ts
@@ -1,13 +1,8 @@
-import { TestBed } from '@angular/core/testing';
-import { DateAdapter } from './dateadapter/date-adapter';
 import { NativeDateAdapter } from './dateadapter/native-date-adapter';
 import {
   DateRange,
   UsaSingleDateSelectionModel,
   UsaRangeDateSelectionModel,
-  UsaDateSelectionModel,
-  USA_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
-  USA_RANGE_DATE_SELECTION_MODEL_PROVIDER,
   USA_SINGLE_DATE_SELECTION_MODEL_FACTORY,
   USA_RANGE_DATE_SELECTION_MODEL_FACTORY,
 } from './date-selection-model';

--- a/projects/uswds-components/src/lib/datepicker/dateadapter/date-adapter.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/dateadapter/date-adapter.spec.ts
@@ -1,0 +1,162 @@
+import { DateAdapter, USA_DATE_LOCALE } from './date-adapter';
+import { NativeDateAdapter } from './native-date-adapter';
+
+/**
+ * A minimal concrete subclass so we can test the abstract base-class methods
+ * (compareDate, sameDate, clampDate, getValidDateOrNull, deserialize).
+ * We delegate everything to NativeDateAdapter and only expose the inherited
+ * base methods under test.
+ */
+class TestDateAdapter extends NativeDateAdapter {
+  constructor() {
+    super('en-US');
+  }
+}
+
+describe('DateAdapter (base class methods)', () => {
+  let adapter: TestDateAdapter;
+
+  beforeEach(() => {
+    adapter = new TestDateAdapter();
+  });
+
+  // -----------------------------------------------------------------------
+  // setLocale / localeChanges
+  // -----------------------------------------------------------------------
+
+  describe('setLocale', () => {
+    it('emits on localeChanges when locale is changed', () => {
+      let emitted = false;
+      adapter.localeChanges.subscribe(() => (emitted = true));
+      adapter.setLocale('fr-FR');
+      expect(emitted).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // compareDate
+  // -----------------------------------------------------------------------
+
+  describe('compareDate', () => {
+    it('returns 0 for equal dates', () => {
+      expect(adapter.compareDate(new Date(2024, 0, 15), new Date(2024, 0, 15))).toBe(0);
+    });
+
+    it('returns negative when first is earlier (same year+month, earlier day)', () => {
+      expect(adapter.compareDate(new Date(2024, 0, 10), new Date(2024, 0, 15))).toBeLessThan(0);
+    });
+
+    it('returns positive when first is later (same year+month, later day)', () => {
+      expect(adapter.compareDate(new Date(2024, 0, 20), new Date(2024, 0, 15))).toBeGreaterThan(0);
+    });
+
+    it('compares by year first', () => {
+      expect(adapter.compareDate(new Date(2023, 11, 31), new Date(2024, 0, 1))).toBeLessThan(0);
+    });
+
+    it('compares by month second', () => {
+      expect(adapter.compareDate(new Date(2024, 2, 1), new Date(2024, 5, 1))).toBeLessThan(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // sameDate
+  // -----------------------------------------------------------------------
+
+  describe('sameDate', () => {
+    it('returns true for two equal dates', () => {
+      expect(adapter.sameDate(new Date(2024, 0, 15), new Date(2024, 0, 15))).toBe(true);
+    });
+
+    it('returns false for different dates', () => {
+      expect(adapter.sameDate(new Date(2024, 0, 15), new Date(2024, 0, 16))).toBe(false);
+    });
+
+    it('returns true when both are null', () => {
+      expect(adapter.sameDate(null, null)).toBe(true);
+    });
+
+    it('returns false when only first is null', () => {
+      expect(adapter.sameDate(null, new Date(2024, 0, 1))).toBe(false);
+    });
+
+    it('returns false when only second is null', () => {
+      expect(adapter.sameDate(new Date(2024, 0, 1), null)).toBe(false);
+    });
+
+    it('returns false when first is invalid, second is valid', () => {
+      expect(adapter.sameDate(new Date(NaN), new Date(2024, 0, 1))).toBe(false);
+    });
+
+    it('returns true when both are invalid dates', () => {
+      expect(adapter.sameDate(new Date(NaN), new Date(NaN))).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clampDate
+  // -----------------------------------------------------------------------
+
+  describe('clampDate', () => {
+    it('returns the date when within min and max', () => {
+      const d = new Date(2024, 5, 15);
+      const result = adapter.clampDate(d, new Date(2024, 0, 1), new Date(2024, 11, 31));
+      expect(adapter.sameDate(result, d)).toBe(true);
+    });
+
+    it('returns min when date is before min', () => {
+      const min = new Date(2024, 5, 1);
+      const result = adapter.clampDate(new Date(2024, 0, 1), min, null);
+      expect(adapter.sameDate(result, min)).toBe(true);
+    });
+
+    it('returns max when date is after max', () => {
+      const max = new Date(2024, 5, 1);
+      const result = adapter.clampDate(new Date(2024, 11, 1), null, max);
+      expect(adapter.sameDate(result, max)).toBe(true);
+    });
+
+    it('handles null min and max — returns the date unchanged', () => {
+      const d = new Date(2024, 5, 15);
+      expect(adapter.sameDate(adapter.clampDate(d, null, null), d)).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getValidDateOrNull
+  // -----------------------------------------------------------------------
+
+  describe('getValidDateOrNull', () => {
+    it('returns the date when valid', () => {
+      const d = new Date(2024, 0, 15);
+      expect(adapter.getValidDateOrNull(d)).toBe(d);
+    });
+
+    it('returns null for an invalid Date', () => {
+      expect(adapter.getValidDateOrNull(new Date(NaN))).toBeNull();
+    });
+
+    it('returns null for a non-Date value', () => {
+      expect(adapter.getValidDateOrNull('2024-01-01')).toBeNull();
+    });
+
+    it('returns null for null', () => {
+      expect(adapter.getValidDateOrNull(null)).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deserialize (base-class path — delegates to NativeDateAdapter override)
+  // -----------------------------------------------------------------------
+
+  describe('deserialize', () => {
+    it('returns null for null input', () => {
+      expect(adapter.deserialize(null)).toBeNull();
+    });
+
+    it('returns the same Date when given a valid Date', () => {
+      const d = new Date(2024, 0, 15);
+      expect(adapter.deserialize(d)).toBe(d);
+    });
+  });
+});

--- a/projects/uswds-components/src/lib/datepicker/dateadapter/date-adapter.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/dateadapter/date-adapter.spec.ts
@@ -1,4 +1,4 @@
-import { DateAdapter, USA_DATE_LOCALE } from './date-adapter';
+import { DateAdapter } from './date-adapter';
 import { NativeDateAdapter } from './native-date-adapter';
 
 /**

--- a/projects/uswds-components/src/lib/datepicker/dateadapter/native-date-adapter.spec.ts
+++ b/projects/uswds-components/src/lib/datepicker/dateadapter/native-date-adapter.spec.ts
@@ -1,0 +1,367 @@
+import { NativeDateAdapter } from './native-date-adapter';
+
+function makeAdapter(locale = 'en-US'): NativeDateAdapter {
+  // NativeDateAdapter constructor takes an optional locale token value
+  return new NativeDateAdapter(locale);
+}
+
+describe('NativeDateAdapter', () => {
+  let adapter: NativeDateAdapter;
+
+  beforeEach(() => {
+    adapter = makeAdapter('en-US');
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic date accessors
+  // -----------------------------------------------------------------------
+
+  describe('getYear', () => {
+    it('returns the full year', () => {
+      expect(adapter.getYear(new Date(2024, 0, 15))).toBe(2024);
+    });
+  });
+
+  describe('getMonth', () => {
+    it('returns 0-indexed month', () => {
+      expect(adapter.getMonth(new Date(2024, 5, 1))).toBe(5);
+    });
+  });
+
+  describe('getDate', () => {
+    it('returns the day of the month', () => {
+      expect(adapter.getDate(new Date(2024, 0, 20))).toBe(20);
+    });
+  });
+
+  describe('getDayOfWeek', () => {
+    it('returns 0 for Sunday', () => {
+      // Jan 7 2024 is a Sunday
+      expect(adapter.getDayOfWeek(new Date(2024, 0, 7))).toBe(0);
+    });
+  });
+
+  describe('getFirstDayOfWeek', () => {
+    it('always returns 0 (Sunday)', () => {
+      expect(adapter.getFirstDayOfWeek()).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Month / date name lists
+  // -----------------------------------------------------------------------
+
+  describe('getMonthNames', () => {
+    it('returns 12 long month names', () => {
+      const names = adapter.getMonthNames('long');
+      expect(names.length).toBe(12);
+      expect(names[0]).toMatch(/January/i);
+    });
+
+    it('returns 12 short month names', () => {
+      const names = adapter.getMonthNames('short');
+      expect(names.length).toBe(12);
+    });
+
+    it('returns 12 narrow month names', () => {
+      expect(adapter.getMonthNames('narrow').length).toBe(12);
+    });
+  });
+
+  describe('getDateNames', () => {
+    it('returns 31 date name strings', () => {
+      const names = adapter.getDateNames();
+      expect(names.length).toBe(31);
+      expect(names[0]).toBe('1');
+    });
+  });
+
+  describe('getDayOfWeekNames', () => {
+    it('returns 7 long weekday names', () => {
+      const names = adapter.getDayOfWeekNames('long');
+      expect(names.length).toBe(7);
+    });
+
+    it('returns 7 short weekday names', () => {
+      expect(adapter.getDayOfWeekNames('short').length).toBe(7);
+    });
+
+    it('returns 7 narrow weekday names', () => {
+      expect(adapter.getDayOfWeekNames('narrow').length).toBe(7);
+    });
+  });
+
+  describe('getYearName', () => {
+    it('returns the year as a string', () => {
+      expect(adapter.getYearName(new Date(2024, 0, 1))).toContain('2024');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Days in month
+  // -----------------------------------------------------------------------
+
+  describe('getNumDaysInMonth', () => {
+    it('returns 31 for January', () => {
+      expect(adapter.getNumDaysInMonth(new Date(2024, 0, 1))).toBe(31);
+    });
+
+    it('returns 29 for February in a leap year', () => {
+      expect(adapter.getNumDaysInMonth(new Date(2024, 1, 1))).toBe(29);
+    });
+
+    it('returns 28 for February in a non-leap year', () => {
+      expect(adapter.getNumDaysInMonth(new Date(2023, 1, 1))).toBe(28);
+    });
+
+    it('returns 30 for April', () => {
+      expect(adapter.getNumDaysInMonth(new Date(2024, 3, 1))).toBe(30);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clone
+  // -----------------------------------------------------------------------
+
+  describe('clone', () => {
+    it('returns a new Date equal to the original', () => {
+      const d = new Date(2024, 5, 15);
+      const c = adapter.clone(d);
+      expect(c).not.toBe(d);
+      expect(c.getTime()).toBe(d.getTime());
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // createDate
+  // -----------------------------------------------------------------------
+
+  describe('createDate', () => {
+    it('creates a date for the given year/month/day', () => {
+      const d = adapter.createDate(2024, 5, 15);
+      expect(adapter.getYear(d)).toBe(2024);
+      expect(adapter.getMonth(d)).toBe(5);
+      expect(adapter.getDate(d)).toBe(15);
+    });
+
+    it('throws for invalid month (< 0) in dev mode', () => {
+      expect(() => adapter.createDate(2024, -1, 1)).toThrow();
+    });
+
+    it('throws for invalid month (> 11) in dev mode', () => {
+      expect(() => adapter.createDate(2024, 12, 1)).toThrow();
+    });
+
+    it('throws for date < 1 in dev mode', () => {
+      expect(() => adapter.createDate(2024, 0, 0)).toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // today
+  // -----------------------------------------------------------------------
+
+  describe('today', () => {
+    it('returns a valid Date', () => {
+      expect(adapter.isValid(adapter.today())).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // parse
+  // -----------------------------------------------------------------------
+
+  describe('parse', () => {
+    it('parses a numeric timestamp', () => {
+      const ts = new Date(2024, 0, 15).getTime();
+      const result = adapter.parse(ts);
+      expect(result).not.toBeNull();
+      expect(result!.getFullYear()).toBe(2024);
+    });
+
+    it('parses an ISO string', () => {
+      const result = adapter.parse('2024-06-15');
+      expect(result).not.toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(adapter.parse('')).toBeNull();
+    });
+
+    it('returns null for null/undefined', () => {
+      expect(adapter.parse(null)).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // format
+  // -----------------------------------------------------------------------
+
+  describe('format', () => {
+    it('formats a date with display options', () => {
+      const d = new Date(2024, 0, 15);
+      const result = adapter.format(d, { year: 'numeric', month: '2-digit', day: '2-digit' });
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('throws when formatting an invalid date', () => {
+      expect(() => adapter.format(new Date(NaN), {})).toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // addCalendarDays
+  // -----------------------------------------------------------------------
+
+  describe('addCalendarDays', () => {
+    it('adds positive days', () => {
+      const d = new Date(2024, 0, 15);
+      const result = adapter.addCalendarDays(d, 10);
+      expect(adapter.getDate(result)).toBe(25);
+    });
+
+    it('subtracts days with negative value', () => {
+      const d = new Date(2024, 0, 15);
+      const result = adapter.addCalendarDays(d, -5);
+      expect(adapter.getDate(result)).toBe(10);
+    });
+
+    it('wraps across month boundaries', () => {
+      const d = new Date(2024, 0, 31);
+      const result = adapter.addCalendarDays(d, 1);
+      expect(adapter.getMonth(result)).toBe(1);
+      expect(adapter.getDate(result)).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // addCalendarMonths
+  // -----------------------------------------------------------------------
+
+  describe('addCalendarMonths', () => {
+    it('adds months forward', () => {
+      const d = new Date(2024, 0, 15);
+      const result = adapter.addCalendarMonths(d, 2);
+      expect(adapter.getMonth(result)).toBe(2);
+    });
+
+    it('wraps across year boundary', () => {
+      const d = new Date(2024, 11, 15);
+      const result = adapter.addCalendarMonths(d, 1);
+      expect(adapter.getYear(result)).toBe(2025);
+      expect(adapter.getMonth(result)).toBe(0);
+    });
+
+    it('clamps day when target month has fewer days', () => {
+      // Jan 31 + 1 month → Feb (should not overflow to March)
+      const d = new Date(2024, 0, 31);
+      const result = adapter.addCalendarMonths(d, 1);
+      expect(adapter.getMonth(result)).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // addCalendarYears
+  // -----------------------------------------------------------------------
+
+  describe('addCalendarYears', () => {
+    it('adds years', () => {
+      const d = new Date(2024, 0, 15);
+      const result = adapter.addCalendarYears(d, 3);
+      expect(adapter.getYear(result)).toBe(2027);
+    });
+
+    it('subtracts years', () => {
+      const d = new Date(2024, 0, 15);
+      const result = adapter.addCalendarYears(d, -4);
+      expect(adapter.getYear(result)).toBe(2020);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // toIso8601
+  // -----------------------------------------------------------------------
+
+  describe('toIso8601', () => {
+    it('produces YYYY-MM-DD format', () => {
+      const d = new Date(2024, 0, 5);
+      expect(adapter.toIso8601(d)).toBe('2024-01-05');
+    });
+
+    it('zero-pads month and day', () => {
+      expect(adapter.toIso8601(new Date(2024, 8, 9))).toBe('2024-09-09');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deserialize
+  // -----------------------------------------------------------------------
+
+  describe('deserialize', () => {
+    it('returns null for empty string', () => {
+      expect(adapter.deserialize('')).toBeNull();
+    });
+
+    it('deserializes a valid ISO 8601 string', () => {
+      const result = adapter.deserialize('2024-06-15');
+      expect(result).not.toBeNull();
+      expect(adapter.isValid(result!)).toBe(true);
+    });
+
+    it('returns invalid date for a non-ISO string', () => {
+      const result = adapter.deserialize('not-a-date');
+      // super.deserialize returns invalid() for non-Date non-null values
+      expect(result === null || !adapter.isValid(result!)).toBe(true);
+    });
+
+    it('returns the same Date instance when given a valid Date', () => {
+      const d = new Date(2024, 0, 15);
+      expect(adapter.deserialize(d)).toBe(d);
+    });
+
+    it('returns null when given null', () => {
+      expect(adapter.deserialize(null)).toBeNull();
+    });
+
+    it('deserializes ISO string with time component', () => {
+      const result = adapter.deserialize('2024-06-15T10:30:00Z');
+      expect(result).not.toBeNull();
+      expect(adapter.isValid(result!)).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isDateInstance / isValid / invalid
+  // -----------------------------------------------------------------------
+
+  describe('isDateInstance', () => {
+    it('returns true for a Date', () => {
+      expect(adapter.isDateInstance(new Date())).toBe(true);
+    });
+
+    it('returns false for a string', () => {
+      expect(adapter.isDateInstance('2024-01-01')).toBe(false);
+    });
+
+    it('returns false for a number', () => {
+      expect(adapter.isDateInstance(123456)).toBe(false);
+    });
+  });
+
+  describe('isValid', () => {
+    it('returns true for a valid Date', () => {
+      expect(adapter.isValid(new Date(2024, 0, 15))).toBe(true);
+    });
+
+    it('returns false for an invalid Date', () => {
+      expect(adapter.isValid(new Date(NaN))).toBe(false);
+    });
+  });
+
+  describe('invalid', () => {
+    it('returns a Date that isValid returns false for', () => {
+      expect(adapter.isValid(adapter.invalid())).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds 11 new spec files comprehensively covering the `datepicker` module — previously the largest untested surface in the library (19 source files, zero specs).

**By area:**

- **`dateadapter/native-date-adapter.spec.ts`** (51 tests): parse, format, calendar arithmetic (days/months/years), ISO 8601 deserialization, edge cases (leap years, month overflow, invalid dates)
- **`dateadapter/date-adapter.spec.ts`** (23 tests): `compareDate`, `sameDate`, `clampDate`, `getValidDateOrNull`, `deserialize`, `setLocale`/`localeChanges`
- **`date-selection-model.spec.ts`** (31 tests): `DateRange`, `UsaSingleDateSelectionModel`, `UsaRangeDateSelectionModel` — add/isValid/isComplete/clone/selectionChanged/ngOnDestroy; factory functions
- **`date-range-selection-strategy.spec.ts`** (10 tests): `DefaultUsaCalendarRangeStrategy.selectionFinished` and `createPreview`; provider factory
- **`date-picker-errors.spec.ts`** (3 tests): `createMissingDateImplError`
- **`calendar.spec.ts`** (17 tests): `UsaCalendar` view switching, date selection, min/max inputs, relay outputs, `ngOnChanges`, `updateTodaysDate`, `_goToDateInView`
- **`calendar/month-view.spec.ts`** (25 tests): full keyboard navigation (ArrowLeft/Right/Up/Down/Home/End/PageUp/PageDown ± Alt), Space/Enter selection, `dateFilter`, `selected` input
- **`calendar/year-view.spec.ts`** (25 tests): same keyboard suite at year granularity, month selection, min/max disable logic
- **`calendar/multi-year-view.spec.ts`** (28 tests): same keyboard suite at decade granularity, year selection, `getNextYears`/`getPreviousYears`, `_getActiveCell`
- **`date-picker-input.spec.ts`** (17 tests): `UsaDatePickerInput` CVA, disabled state, `getConnectedOverlayOrigin`, Alt+ArrowDown open, `_onInput`/`_onChange`/`_onBlur`, `stateChanges`
- **`date-picker-button.spec.ts`** (6 tests): `UsaDatePickerButton` construction, disabled inheritance, `_toggle` guard (null picker, disabled)

**Coverage improvement:**

| Metric | Floor | Before | After |
|---|---|---|---|
| Statements | 81% | 81% | **88.21%** |
| Branches | 83% | 83% | **88.67%** |
| Functions | 48% | 48% | **72.03%** |
| Lines | 81% | 81% | **88.21%** |

`coverage-floor.json` is **not edited** in this PR per the ratchet policy (#259). A maintainer can run `npm run coverage:bump` to lock in the new floors after this merges.

## Motivation and Context

Closes #247

## Type of Change (Select One and Apply Label)

- [ ] Bug fix (non-breaking change which fixes an issue) → Apply `bugfix` label
- [x] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [ ] Documentation / configuration update → Apply `documentation` label

## How to Test

1. `cd` into the worktree and install: `npm ci`
2. Run the test suite with coverage: `npm run test:components`
3. Verify all 548 tests pass (0 failures)
4. Run the coverage gate: `npm run coverage:check`
5. Confirm all four metrics are above their floors

**Expected result:** `✓ Coverage gate passed.` with statements/lines ≥81%, branches ≥83%, functions ≥48%.

## Screenshots (if appropriate)

N/A — test-only changes, no UI modifications.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [ ] `lint` passes (`npm run lint`) — lint target not configured in this repo (known issue per AGENTS.md)
- [ ] `build-prod` passes (`npm run build-prod`)
- [x] Tests pass and coverage is reported (`npm run test:components` — 548 passed)
- [ ] If this change requires a documentation update, I have updated it accordingly
- [ ] If there are dependent changes, they have been merged and published in downstream modules
