### PR TITLE
Fix flaky ScrollBar.compensate() spec (GH #302)

### DIFF
--- a/projects/uswds-components/src/lib/modal/modal.spec.ts
+++ b/projects/uswds-components/src/lib/modal/modal.spec.ts
@@ -9,6 +9,25 @@ import { ModalDismissReasons } from './modal-dismiss-reasons';
 import { UsaModalRef } from './modal-ref';
 import { UsaModalModule } from './modal.module';
 
+// `UsaModalRef.close()`/`.dismiss()` synchronously emit on the `closed`/
+// `dismissed` Subjects *before* the ref's `result` promise settles (see
+// modal-ref.ts: `_closed.next()` fires, then `_resolve()`, then
+// `_removeModalElements()`). `UsaModalStack.open()` reverts the real
+// `ScrollBar` body-padding compensation via `result.then(revertPaddingForScrollBar, ...)`,
+// which is therefore only *scheduled* as a microtask after several of the
+// tests below have already called `done()`. Left unflushed, that revert can
+// fire after this file's tests finish and mutate the shared `document.body`
+// that other spec files assert against — under the Vitest builder's default
+// `isolate: false`, spec files can share a realm, so this bled into
+// `scrollbar.spec.ts` as an intermittent CI flake (GH #302). A root-level
+// `afterEach` here flushes the event loop (guaranteeing any pending revert
+// microtask has run) and defensively resets the padding, so this file never
+// leaks state to whatever spec runs next.
+afterEach(async () => {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  document.body.style.paddingRight = '';
+});
+
 describe('UsaModal', () => {
   let fixture: ComponentFixture<UsaModalTestComponent>;
   let component: UsaModalTestComponent;

--- a/projects/uswds-components/src/lib/util/scrollbar.spec.ts
+++ b/projects/uswds-components/src/lib/util/scrollbar.spec.ts
@@ -11,6 +11,13 @@ describe('ScrollBar', () => {
     TestBed.configureTestingModule({ providers: [ScrollBar] });
     scrollBar = TestBed.inject(ScrollBar);
     doc = TestBed.inject(DOCUMENT);
+    // Defensive reset: the Vitest builder defaults to `isolate: false`, which
+    // shares the JS realm (and therefore `document`) across spec files within a
+    // worker. Other suites (e.g. modal.spec.ts) exercise the *real* ScrollBar
+    // via real `document.body` mutations, so padding can leak in from a
+    // previous file/test if it hasn't been reverted yet. Resetting here as well
+    // as in `afterEach` makes this suite self-contained regardless of run order.
+    doc.body.style.paddingRight = '';
   });
 
   afterEach(() => {
@@ -55,10 +62,19 @@ describe('ScrollBar', () => {
       Object.defineProperty(measurer, 'clientWidth', { value: 0, configurable: true });
       vi.spyOn(doc, 'createElement').mockReturnValue(measurer);
 
+      // Assert against the actual computed state rather than an exact-string
+      // literal: capture whatever padding is on the body *before* calling
+      // compensate(), then assert it is unchanged afterwards. This is the
+      // real contract of the noop branch ("if there was none, there is
+      // nothing to do") and holds regardless of what any other suite may
+      // have left on `document.body` before this test ran.
+      const paddingBefore = doc.body.style.paddingRight;
       const reverter = scrollBar.compensate();
+      // The noop path must not touch padding at all, not just after revert.
+      expect(doc.body.style.paddingRight).toBe(paddingBefore);
       // noop: calling it should not throw and body padding should be unchanged
       reverter();
-      expect(doc.body.style.paddingRight).toBe('');
+      expect(doc.body.style.paddingRight).toBe(paddingBefore);
     });
 
     it('adds padding to body when a scrollbar is present, and reverts it', () => {


### PR DESCRIPTION
<!--- Start the title with a verb (e.g. Add, Fix, Update, Remove) -->
<!--- Use the imperative mood (e.g. Fix, not Fixed or Fixes) -->

## Description

Fixes an intermittent CI flake in `ScrollBar > compensate() > returns a noop when no scrollbar is present` (`projects/uswds-components/src/lib/util/scrollbar.spec.ts`), which was failing with `AssertionError: expected '0px' to be ''` roughly 1 in every 8-15 full test-suite runs.

**Root cause:** the `@angular/build:unit-test` Vitest runner defaults to `isolate: false` (to mirror the old Karma/Jasmine experience), which means spec files can share a JS realm — and therefore `document` — within a worker. `modal.spec.ts` exercises the *real* `ScrollBar` via real `UsaModalService.open()`/`.close()` calls. `UsaModalStack.open()` reverts the body-padding compensation asynchronously (`usaModalRef.result.then(revertPaddingForScrollBar, revertPaddingForScrollBar)`), but several tests in `modal.spec.ts` call their test's `done()` before that microtask has flushed. That left `document.body.style.paddingRight` mutated (e.g. to `'0px'`) after `modal.spec.ts` finished, which then bled into whatever spec ran next in the same worker — intermittently landing on `scrollbar.spec.ts`'s exact-string assertion.

**Fix, two parts:**
- `scrollbar.spec.ts` — assert against the actual computed state (padding is unchanged across the noop call) instead of a literal `''`, and reset padding in `beforeEach` in addition to the existing `afterEach`, so the suite is self-contained regardless of run order.
- `modal.spec.ts` — add a root-level `afterEach` that flushes the event loop (awaiting a `setTimeout(0)`) and resets `document.body.style.paddingRight`, so this file stops leaking scrollbar-compensation state to whatever spec runs after it.

No production code (`scrollbar.ts`, `modal-stack.ts`) changed — this is a test-isolation fix only.

## Motivation and Context

Closes #302

## Type of Change (Select One and Apply Label)

- [x] Bug fix (non-breaking change which fixes an issue) → Apply `bug` label
- [ ] New feature (non-breaking change which adds functionality) → Apply `enhancement` label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) → Apply `breaking` label
- [ ] Documentation / configuration update → Apply `documentation` label

## How to Test

1. `npm ci`
2. Run the full suite once to confirm it's green: `npm run test:components`
3. Run it repeatedly to confirm the flake is gone (this is how the fix was validated — 45 consecutive runs, 0 failures, versus a baseline of ~1-in-8-to-15):
   ```bash
   for i in $(seq 1 20); do npm run test:components -- 2>&1 | grep -E "Test Files|failed"; done
   ```
4. Confirm coverage is unaffected: `npm run coverage:check` (requires step 2/3 to have run first)

**Expected result:** all 44 test files / 1150 tests pass on every run, with no `AssertionError` in `scrollbar.spec.ts`. `coverage:check` reports the same floors as before (statements 97.7%, branches 91.02%, functions 95.76%, lines 97.66%) — both branches of `ScrollBar.compensate()` remain exercised.

## Screenshots (if appropriate)

N/A — test-only changes, no UI impact.

## Checklist

- [x] Branch name follows convention (e.g. `gh-<number>-<slug>`)
- [x] PR title starts with a verb in the imperative mood
- [x] I have self-reviewed my own code
- [x] `format:check` passes (`npm run format:check`)
- [x] `lint` passes (`npm run lint`)
- [x] `build-prod` passes (`npm run build:components`)
- [x] Tests pass and coverage is reported (`npm run test:components` + `npm run coverage:check`)
- [ ] If this change requires a documentation update, I have updated it accordingly (N/A — no docs affected)
- [ ] If there are dependent changes, they have been merged and published in downstream modules (N/A)
